### PR TITLE
feat: add matched_queries and highlight to Snap.Hit

### DIFF
--- a/lib/snap/hit.ex
+++ b/lib/snap/hit.ex
@@ -2,7 +2,17 @@ defmodule Snap.Hit do
   @moduledoc """
   Represents an individual hit dictionary from a [Search API](https://www.elastic.co/guide/en/elasticsearch/reference/current/search.html) response.
   """
-  defstruct [:index, :type, :id, :score, :source, :fields, :explanation]
+  defstruct ~w[
+    index
+    type
+    id
+    score
+    source
+    fields
+    explanation
+    matched_queries
+    highlight
+  ]a
 
   def new(response) do
     %__MODULE__{
@@ -12,7 +22,9 @@ defmodule Snap.Hit do
       score: response["_score"],
       source: response["_source"],
       fields: response["fields"],
-      explanation: response["_explanation"]
+      explanation: response["_explanation"],
+      matched_queries: response["matched_queries"],
+      highlight: response["highlight"]
     }
   end
 
@@ -23,6 +35,8 @@ defmodule Snap.Hit do
           score: float() | nil,
           source: map() | nil,
           fields: map() | nil,
-          explanation: map() | nil
+          explanation: map() | nil,
+          matched_queries: list(String.t()) | nil,
+          highlight: map() | nil
         }
 end

--- a/test/fixtures/search_response.json
+++ b/test/fixtures/search_response.json
@@ -21,6 +21,13 @@
           "job_title": "Science teacher",
           "location": { "lat": 51.735802, "lon": 0.469708 },
           "timestamp": "1610052006"
+        },
+        "matched_queries": ["query_a"],
+        "highlight": {
+          "message": [
+            " with the <em>number</em>",
+            " <em>1</em>"
+          ]
         }
       },
       {

--- a/test/search_response_test.exs
+++ b/test/search_response_test.exs
@@ -24,6 +24,8 @@ defmodule Snap.SearchResponseTest do
     assert hit.type == "_doc"
     assert hit.id == "adz-2553823"
     assert hit.score == 1.0
+    assert hit.matched_queries == ["query_a"]
+    assert hit.highlight == %{"message" => [" with the <em>number</em>", " <em>1</em>"]}
 
     assert hit.source == %{
              "adzuna_url" =>


### PR DESCRIPTION
Finally got around to opening this PR, sorry it took so long (given that it's not a lot of code).

As discussed in https://github.com/breakroom/snap/issues/3 we're adding `matched_queries` and `highlight` to the `Snap.Hit`. We also discussed adding these sort of fields into an `extras` key, but given that by now `explanation` was also added, I don't think it would be consistent.