### PR TITLE
Parse aggregations in SearchResponse

### DIFF
--- a/lib/snap/aggregation.ex
+++ b/lib/snap/aggregation.ex
@@ -1,0 +1,26 @@
+defmodule Snap.Aggregation do
+  @moduledoc """
+  Represents an individual aggregation dictionary from a
+  [Search Aggregation API](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations.html)
+  response.
+  """
+  defstruct ~w[
+    buckets
+    doc_count_error_upper_bound
+    sum_other_doc_count
+  ]a
+
+  def new(response) do
+    %__MODULE__{
+      buckets: response["buckets"],
+      doc_count_error_upper_bound: response["doc_count_error_upper_bound"],
+      sum_other_doc_count: response["sum_other_doc_count"]
+    }
+  end
+
+  @type t :: %__MODULE__{
+          buckets: list(map()),
+          doc_count_error_upper_bound: integer(),
+          sum_other_doc_count: integer()
+        }
+end

--- a/lib/snap/search_response.ex
+++ b/lib/snap/search_response.ex
@@ -4,7 +4,7 @@ defmodule Snap.SearchResponse do
 
   Implements `Enumerable`, so you can iterate directly over the struct.
   """
-  defstruct [:took, :timed_out, :shards, :hits, :scroll_id, :pit_id]
+  defstruct [:took, :timed_out, :shards, :hits, :aggregations, :scroll_id, :pit_id]
 
   def new(response) do
     %__MODULE__{
@@ -12,6 +12,7 @@ defmodule Snap.SearchResponse do
       timed_out: response["timed_out"],
       shards: response["_shards"],
       hits: Snap.Hits.new(response["hits"]),
+      aggregations: build_aggregations(response["aggregations"]),
       scroll_id: response["_scroll_id"],
       pit_id: response["pit_id"]
     }
@@ -22,9 +23,18 @@ defmodule Snap.SearchResponse do
           timed_out: boolean(),
           shards: map(),
           hits: Snap.Hits.t(),
+          aggregations: %{String.t() => Snap.Aggregation.t()} | nil,
           scroll_id: String.t() | nil,
           pit_id: map() | nil
         }
+
+  def build_aggregations(nil) do
+    nil
+  end
+
+  def build_aggregations(aggregations) when is_map(aggregations) do
+    Map.new(aggregations, fn {key, value} -> {key, Snap.Aggregation.new(value)} end)
+  end
 
   defimpl Enumerable do
     def reduce(_, {:halt, acc}, _fun), do: {:halted, acc}

--- a/test/fixtures/search_response_agg.json
+++ b/test/fixtures/search_response_agg.json
@@ -1,0 +1,30 @@
+{
+  "_shards": {
+    "failed": 0,
+    "skipped": 0,
+    "successful": 1,
+    "total": 1
+  },
+  "aggregations": {
+    "season_values": {
+      "buckets": [
+        {
+          "doc_count": 69406,
+          "key": "summer"
+        }
+      ],
+      "doc_count_error_upper_bound": 0,
+      "sum_other_doc_count": 0
+    }
+  },
+  "hits": {
+    "hits": [],
+    "max_score": null,
+    "total": {
+      "relation": "gte",
+      "value": 10000
+    }
+  },
+  "timed_out": false,
+  "took": 2
+}

--- a/test/search_response_test.exs
+++ b/test/search_response_test.exs
@@ -3,7 +3,7 @@ defmodule Snap.SearchResponseTest do
 
   alias Snap.SearchResponse
 
-  test "new/1" do
+  test "new/1 without aggregations" do
     json =
       Path.join([__DIR__, "fixtures", "search_response.json"])
       |> File.read!()
@@ -14,6 +14,7 @@ defmodule Snap.SearchResponseTest do
     assert response.timed_out == false
     assert response.shards == %{"total" => 5, "successful" => 5, "skipped" => 0, "failed" => 0}
     assert Enum.count(response) == 10
+    assert is_nil(response.aggregations)
 
     assert response.hits.total == %{"value" => 10_000, "relation" => "gte"}
     assert response.hits.max_score == 1.0
@@ -39,6 +40,22 @@ defmodule Snap.SearchResponseTest do
              "job_title" => "Science teacher",
              "location" => %{"lat" => 51.735802, "lon" => 0.469708},
              "timestamp" => "1610052006"
+           }
+  end
+
+  test "new/1 with aggregations" do
+    json =
+      Path.join([__DIR__, "fixtures", "search_response_agg.json"])
+      |> File.read!()
+      |> Jason.decode!()
+
+    response = SearchResponse.new(json)
+    assert Enum.count(response.aggregations) == 1
+
+    assert response.aggregations["season_values"] == %Snap.Aggregation{
+             buckets: [%{"doc_count" => 69406, "key" => "summer"}],
+             doc_count_error_upper_bound: 0,
+             sum_other_doc_count: 0
            }
   end
 end


### PR DESCRIPTION
Hey, thanks for open sourcing, I quite like the simple design of this library!

For my use case, I use the Search API to get aggregations, in a query like:

```elixir
%{
  aggs: %{season_values: %{terms: %{field: "season.keyword", size: 100}}},
  query: %{terms: %{"season.keyword": ["summer"]}},
  size: 0
}
```

However, the aggregation result was being ignored in the SearchResponse, so this PR adds support for that :)