### PR TITLE
Enables configuration of HTTP transport options

### DIFF
--- a/lib/snap/supervisor.ex
+++ b/lib/snap/supervisor.ex
@@ -3,6 +3,7 @@ defmodule Snap.Cluster.Supervisor do
 
   use Supervisor
   @default_pool_size 5
+  @default_conn_opts []
 
   def start_link(cluster, otp_app, config) do
     Supervisor.start_link(__MODULE__, {cluster, otp_app, config}, name: cluster)
@@ -32,11 +33,12 @@ defmodule Snap.Cluster.Supervisor do
   defp finch_config(cluster, config) do
     url = Keyword.fetch!(config, :url)
     size = Keyword.get(config, :pool_size, @default_pool_size)
+    conn_opts = Keyword.get(config, :conn_opts, @default_conn_opts)
 
     [
       name: connection_pool_name(cluster),
       pools: %{
-        url => [size: size, count: 1]
+        url => [size: size, count: 1, conn_opts: conn_opts]
       }
     ]
   end


### PR DESCRIPTION
Hi, I've been using Elastic's official Helm chart to deploy an ElasticSearch cluster with self-signed certificates per [this example](https://github.com/elastic/helm-charts/tree/7.15/elasticsearch/examples/security). Because the underlying HTTP library which Finch uses (Mint) sets `:verify_peer` as the default for the `:verify` transport option, using a self-signed certificate will throw this error:

```elixir
unknown_ca, 'TLS client: In state wait_cert_cr at ssl_handshake.erl:2015 generated CLIENT ALERT: Fatal - Unknown CA\n'}}}], message: "1 error occurred"}}
    (spellbook 0.1.0) lib/spell_book/identify/spell.ex:25: anonymous fn/3 in SpellBook.Identify.Spell.handle_events/3
    (stdlib 3.16.1) maps.erl:410: :maps.fold_1/3
    (spellbook 0.1.0) lib/spell_book/identify/spell.ex:22: SpellBook.Identify.Spell.handle_events/3
    (gen_stage 1.1.2) lib/gen_stage.ex:2471: GenStage.consumer_dispatch/6
    (stdlib 3.16.1) gen_server.erl:695: :gen_server.try_dispatch/4
    (stdlib 3.16.1) gen_server.erl:771: :gen_server.handle_msg/6
    (stdlib 3.16.1) proc_lib.erl:226: :proc_lib.init_p_do_apply/3
Last message: {:"$gen_consumer", {#PID<0.990.0>, #Reference<0.3634801039.2851078146.76530>}, [%{campaign_id: "2", from: "-Mm3r0wYkYaAJNXi_VG2", payload: "{\"isOffer\":true,\"sdpMessage\":\"v=0\\r\\no=- 7484509318176042000 2 IN IP4 127.0.0.1\\r\\ns=-\\r\\nt=0 0\\r\\na=group:BUNDLE 0 1\\r\\na=extmap-allow-mixed\\r\\na=msid-semantic:WMS V2z6s0rFJE5B9uMwSr7Ugz4yZEvlBVzl6F92\\r\\na=ice-options:trickle\\r\\nm=audio 9 UDP/TLS/RTP/SAVPF 111 103 104 9 0 8 106 105 13 110 112 113 126\\r\\nc=IN IP4 0.0.0.0\\r\\na=rtcp:9 IN IP4 0.0.0.0\\r\\na=ice-ufrag:Gw3d\\r\\na=ice-pwd:gVoOrhwkad5w3oWLlxr2YPgY\\r\\na=fingerprint:sha-256 78:FB:F9:24:27:68:BD:F8:98:6E:52:9B:6C:CC:44:0B:CE:5A:D5:60:51:10:06:B4:12:FF:19:EE:08:8D:5A:6A\\r\\na=setup:actpass\\r\\na=mid:0\\r\\na=extmap:1 urn:ietf:params:rtp-hdrext:ssrc-audio-level\\r\\na=extmap:2 http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time\\r\\na=extmap:3 http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01\\r\\na=extmap:4 urn:ietf:params:rtp-hdrext:sdes:mid\\r\\na=extmap:5 urn:ietf:params:rtp-hdrext:sdes:rtp-stream-id\\r\\na=extmap:6 urn:ietf:params:rtp-hdrext:sdes:repaired-rtp-stream-id\\r\\na=sendrecv\\r\\na=msid:V2z6s0rFJE5B9uMwSr7Ugz4yZEvlBVzl6F92 c8e33426-af7c-4ee7-9e11-54a144be9a29\\r\\na=rtcp-mux\\r\\na=rtpmap:111 opus/48000/2\\r\\na=rtcp-fb:111 transport-cc\\r\\na=fmtp:111 minptime=10;useinbandfec=1\\r\\na=rtpmap:103 ISAC/16000\\r\\na=rtpmap:104 ISAC/32000\\r\\na=rtpmap:9 G722/8000\\r\\na=rtpmap:0 PCMU/8000\\r\\na=rtpmap:8 PCMA/8000\\r\\na=rtpmap:106 CN/32000\\r\\na=rtpmap:105 CN/16000\\r\\na=rtpmap:13 CN/8000\\r\\na=rtpmap:110 telephone-event/48000\\r\\na=rtpmap:112 telephone-event/32000\\r\\na=rtpmap:113 telephone-event/16000\\r\\na=rtpmap:126 telephone-event/8000\\r\\na=ssrc:3855647946 cname:GWr8TiQlhqom0FKI\\r\\na=ssrc:3855647946 msid:V2z6s0rFJE5B9uMwSr7Ugz4yZEvlBVzl6F92 c8e33426-af7c-4ee7-9e11-54a144be9a29\\r\\na=ssrc:3855647946 mslabel:V2z6s0rFJE5B9uMwSr7Ugz4yZEvlBVzl6F92\\r\\na=ssrc:3855647946 label:c8e33426-af7c-4ee7-9e11-54a144be9a29\\r\\nm=video 9 UDP/TLS/RTP/SAVPF 96 97 98 99 100 101 102 121 127 120 125 107 108 109 35 36 124 119 123\\r\\nc=IN IP4 0.0.0.0\\r\\na=rtcp:9 IN IP4 0.0.0.0\\r\\na=ice-ufrag:Gw3d\\r\\na=ice-pwd:gVoOrhwkad5w3oWLlxr2YPgY\\r\\na=fingerprint:sha-256 78:FB:F9:24:27:68:BD:F8:98:6E:52:9B:6C:CC:44:0B:CE:5A:D5:60:51:10:06:B4:12:FF:19:EE:08:8D:5A:6A\\r\\na=setup:actpass\\r\\na=mid:1\\r\\na=extmap:14 urn:ietf:params:rtp-hdrext:toffset\\r\\na=extmap:2 http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time\\r\\na=extmap:13 urn:3gpp:video-orientation\\r\\na=extmap:3 http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01\\r\\na=extmap:12 http://www.webrtc.org/experiments/rtp-hdrext/playout-delay\\r\\na=extmap:11 http://www.webrtc.org/experiments/rtp-hdrext/video-content-type\\r\\na=extmap:7 http://www.webrtc.org/experiments/rtp-hdrext/video-timing\\r\\na=extmap:8 http://www.webrtc.org/experiments/rtp-hdrext/color-space\\r\\na=extmap:4 urn:ietf:params:rtp-hdrext:sdes:mid\\r\\na=extmap:5 urn:ietf:params:rtp-hdrext:sdes:rtp-stream-id\\r\\na=extmap:6 urn:ietf:params:rtp-hdrext:sdes:repaired-rtp-stream-id\\r\\na=sendrecv\\r\\na=msid:V2z6s0rFJE5B9uMwSr7Ugz4yZEvlBVzl6F92 06d69e10-740c-46a9-a855-27130aa11b61\\r\\na=rtcp-rsize\\r\\na=rtcp-mux\\r\\na=rtpmap:96 VP8/90000\\r\\na=rtcp-fb:96 goog-remb\\r\\na=rtcp-fb:96 transport-cc\\r\\na=rtcp-fb:96 ccm fir\\r\\na=rtcp-fb:96 nack\\r\\na=rtcp-fb:96 nack pli\\r\\na=rtpmap:97 rtx/90000\\r\\na=fmtp:97 apt=96\\r\\na=rtpmap:98 VP9/90000\\r\\na=rtcp-fb:98 goog-remb\\r\\na=rtcp-fb:98 transport-cc\\r\\na=rtcp-fb:98 ccm fir\\r\\na=rtcp-fb:98 nack\\r\\na=rtcp-fb:98 nack pli\\r\\na=fmtp:98 profile-id=0\\r\\na=rtpmap:99 rtx/90000\\r\\na=fmtp:99 apt=98\\r\\na=rtpmap:100 VP9/90000\\r\\na=rtcp-fb:100 goog-remb\\r\\na=rtcp-fb:100 transport-cc\\r\\na=rtcp-fb:100 ccm fir\\r\\na=rtcp-fb:100 nack\\r\\na=rtcp-fb:100 nack pli\\r\\na=fmtp:100 profile-id=2\\r\\na=rtpmap:101 rtx/90000\\r\\na=fmtp:101 apt=100\\r\\na=rtpmap:102 H264/90000\\r\\na=rtcp-fb:102 goog-remb\\r\\na=rtcp-fb:102 transport-cc\\r\\na=rtcp-fb:102 ccm fir\\r\\na=rtcp-fb:102 nack\\r\\na=rtcp-fb:102 nack pli\\r\\na=fmtp:102 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42001f\\r\\na=rtpmap:121 rtx/90000\\r\\na=fmtp:121 apt=102\\r\\na=rtpmap:127 H264/90000\\r\\na=rtcp-fb:127 goog-remb\\r\\na=rtcp-fb:127 transport-cc\\r\\na=rtcp-fb:127 ccm fir\\r\\na=rtcp-fb:127 nack\\r\\na=rtcp-fb:127 nack " <> ..., storage_path: "dev-campaign-2-2dWf9u3eg009PSt0DRGKCw", to: "-Mm3r7OsP-EbWTgOfDH2"}]}
```

If `:verify` is set to `:verify_none`, then the ElasticSearch API requests can succeed  as expected:

```elixir
09:38:27.079 [warn] Description: 'Authenticity is not established by certificate path validation'
     Reason: 'Option {verify, verify_peer} and cacertfile/cacerts is missing'

09:38:27.321 [warn] Description: 'Authenticity is not established by certificate path validation'
     Reason: 'Option {verify, verify_peer} and cacertfile/cacerts is missing'

09:38:27.795 [debug] Elasticsearch POST request path=/campaign-2-ice-2021.10.28/_bulk response=475ms decode=0ms total=475ms
09:38:27.803 [debug] Elasticsearch POST request path=/campaign-2-ice-2021.10.28/_bulk response=725ms decode=0ms total=725ms
```

Allowing users of this library to pass in the connection options therefore seems like the right thing to do here i.e. 

```elixir
config :spellbook, SpellBook.Cluster,
  url:
    "#{System.get_env("ELASTIC_PROTOCOL", "http")}://#{System.get_env("ELASTIC_HOST", "app.roll20.local")}:#{System.get_env("ELASTIC_PORT", "9200")}",
  username: "elastic",
  password: System.get_env("ELASTIC_PASSWORD", ""),
  conn_opts: [
    transport_opts: [
      verify: :verify_none
    ]
  ]
```

Thoughts?