### PR TITLE
Support http client adapters for cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,4 +70,27 @@ Now you can perform operations on your cluster:
 {:ok, %{"count" => count}} = MyApp.Cluster.get("/my-index/_count")
 ```
 
+## Testing
+
+If you want to test your app that uses this library, but don't want to have integration tests 
+with a Elasticsearch instance running in you local dev environment, 
+you can mock the responses using a custom HTTP client adapter.
+
+Supposing you are using [mox](https://github.com/dashbitco/mox), you can do something like this:
+
+```elixir
+# in test_helper.exs
+Mox.defmock(HTTPClientMock, for: Snap.HTTPClient)
+Mox.stub(HTTPClientMock, :child_spec, fn _config -> :skip end)
+
+# in config/test.exs
+config :my_app, MyApp.Cluster, http_client_adapter: HTTPClientMock
+
+# in a test file
+Mox.expect(HTTPClientMock, :request, fn _cluster, _method, _url, _headers, _body, _opts
+  body = "{}" # valid json
+  {:ok, %Snap.HTTPClient.Response{status: 200, headers: [], body: body}}
+end)
+```
+
 See the [API documentation](https://hexdocs.pm/snap) for more advanced features.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ The package can be installed by adding `snap` to your list of dependencies in
 ```elixir
 def deps do
   [
-    {:snap, "~> 0.5"}
+    {:snap, "~> 0.5"},
+    {:finch, "~> 0.8"}, # By default, Snap uses Finch to make HTTP requests
   ]
 end
 ```

--- a/dev.exs
+++ b/dev.exs
@@ -1,0 +1,15 @@
+defmodule Snap.Dev.Cluster do
+  @moduledoc false
+  use Snap.Cluster, otp_app: :snap
+end
+
+Logger.configure(level: :debug)
+
+Task.start(fn ->
+  children = [
+    {Snap.Dev.Cluster, [url: "http://localhost:9200"]},
+  ]
+
+  {:ok, _} = Supervisor.start_link(children, strategy: :one_for_one)
+  Process.sleep(:infinity)
+end)

--- a/lib/snap.ex
+++ b/lib/snap.ex
@@ -16,6 +16,9 @@ defmodule Snap do
 
   Additionally, there are other supporting modules:
 
+  * `Snap.HTTPClient` - defines how to send HTTP requests.
+    Comes with a built in adapter for `Finch` (`Snap.HTTPClient.Adapters.Finch`)
+
   * `Snap.Auth` - defines how an HTTP request is modified to include
     authentication headers. `Snap.Auth.Plain` implements HTTP Basic Auth.
 
@@ -67,10 +70,10 @@ defmodule Snap do
   * `password` - the password used to access the cluster
   * `auth` - the auth module used to configure the HTTP authentication headers
     (defaults to `Snap.Auth.Plain`)
-  * `pool_size` - the maximum size of the HTTP connection pool (defaults to 5)
-  * `conn_opts` - a Keyword list of connection options passed to the underlying
-     HTTP connection
-  * `telemetry_prefix` - the prefix of the telemetry events (default to
+  * `http_client_adapter` - the adapter that will be used to send HTTP requests.
+    Check `Snap.HTTPClient` for more information.
+    (defaults to `Snap.HTTPClient.Adapters.Finch`)
+  * `telemetry_prefix` - the prefix of the telemetry events (defaults to
     `[:my_app, :snap]`)
 
   ## Telemetry

--- a/lib/snap.ex
+++ b/lib/snap.ex
@@ -103,21 +103,21 @@ defmodule Snap do
 
   @doc false
   def get(cluster, path, params \\ [], headers \\ [], opts \\ []) do
-    Request.request(cluster, "GET", path, nil, params, headers, opts)
+    Request.request(cluster, :get, path, nil, params, headers, opts)
   end
 
   @doc false
   def post(cluster, path, body \\ nil, params \\ [], headers \\ [], opts \\ []) do
-    Request.request(cluster, "POST", path, body, params, headers, opts)
+    Request.request(cluster, :post, path, body, params, headers, opts)
   end
 
   @doc false
   def put(cluster, path, body \\ nil, params \\ [], headers \\ [], opts \\ []) do
-    Request.request(cluster, "PUT", path, body, params, headers, opts)
+    Request.request(cluster, :put, path, body, params, headers, opts)
   end
 
   @doc false
   def delete(cluster, path, params \\ [], headers \\ [], opts \\ []) do
-    Request.request(cluster, "DELETE", path, nil, params, headers, opts)
+    Request.request(cluster, :delete, path, nil, params, headers, opts)
   end
 end

--- a/lib/snap/auth/auth.ex
+++ b/lib/snap/auth/auth.ex
@@ -3,17 +3,23 @@ defmodule Snap.Auth do
   Defines how HTTP request is transformed to add authentication.
   """
 
-  @type method :: String.t()
-  @type url :: String.t()
-  @type headers :: Mint.Types.headers()
-  @type body :: iodata()
-  @type opts :: Keyword.t()
-  @type config :: Keyword.t()
+  alias Snap.Cluster
+  alias Snap.HTTPClient
 
-  @type response :: {:ok, {method, url, headers, body}} | {:error, term()}
+  @type t :: module()
+
+  @type response ::
+          {:ok, {HTTPClient.method(), HTTPClient.url(), HTTPClient.headers(), HTTPClient.body()}}
+          | {:error, term()}
 
   @doc """
   Modifies an HTTP request to include authentication details
   """
-  @callback sign(config, method, url, headers, body) :: response()
+  @callback sign(
+              Cluster.config_opts(),
+              HTTPClient.method(),
+              HTTPClient.url(),
+              HTTPClient.headers(),
+              HTTPClient.body()
+            ) :: response()
 end

--- a/lib/snap/cluster.ex
+++ b/lib/snap/cluster.ex
@@ -49,19 +49,19 @@ defmodule Snap.Cluster do
       end
 
       def get(path, params \\ [], headers \\ [], opts \\ []) do
-        Request.request(__MODULE__, "GET", path, nil, params, headers, opts)
+        Request.request(__MODULE__, :get, path, nil, params, headers, opts)
       end
 
       def post(path, body \\ nil, params \\ [], headers \\ [], opts \\ []) do
-        Request.request(__MODULE__, "POST", path, body, params, headers, opts)
+        Request.request(__MODULE__, :post, path, body, params, headers, opts)
       end
 
       def put(path, body \\ nil, params \\ [], headers \\ [], opts \\ []) do
-        Request.request(__MODULE__, "PUT", path, body, params, headers, opts)
+        Request.request(__MODULE__, :put, path, body, params, headers, opts)
       end
 
       def delete(path, params \\ [], headers \\ [], opts \\ []) do
-        Request.request(__MODULE__, "DELETE", path, nil, params, headers, opts)
+        Request.request(__MODULE__, :delete, path, nil, params, headers, opts)
       end
 
       def child_spec(opts) do

--- a/lib/snap/cluster.ex
+++ b/lib/snap/cluster.ex
@@ -20,8 +20,7 @@ defmodule Snap.Cluster do
   config :my_app, MyApp.Cluster,
     url: "http://localhost:9200",
     username: "username",
-    password: "password",
-    pool_size: 10
+    password: "password"
   ```
   """
   defmacro __using__(opts) do
@@ -94,7 +93,7 @@ defmodule Snap.Cluster do
   @type body :: String.t() | nil | binary() | map()
 
   @typedoc "Any additional HTTP headers sent with the request"
-  @type headers :: Mint.Types.headers()
+  @type headers :: Snap.HTTPClient.headers()
 
   @typedoc "Options passed through to the request"
   @type opts :: Keyword.t()
@@ -106,7 +105,19 @@ defmodule Snap.Cluster do
   @type success :: {:ok, map()}
 
   @typedoc "An error from an HTTP operation"
-  @type error :: {:error, Snap.ResponseError.t() | Mint.Types.error() | Jason.DecodeError.t()}
+  @type error ::
+          {:error, Snap.ResponseError.t() | Snap.HTTPClient.Error.t() | Jason.DecodeError.t()}
+
+  @typedoc "Options available for configuring the Cluster"
+  @type config_opts :: [
+          url: String.t(),
+          username: String.t(),
+          password: String.t(),
+          auth: Snap.Auth.t(),
+          telemetry_prefix: list(atom()),
+          http_client_adapter:
+            Snap.HTTPClient.t() | {Snap.HTTPClient.t(), adapter_config :: Keyword.t()}
+        ]
 
   @doc """
   Sends a GET request.
@@ -116,8 +127,7 @@ defmodule Snap.Cluster do
   * `{:ok, response}` - where response is a map representing the parsed JSON response.
   * `{:error, error}` - where the error can be a struct of either:
     * `Snap.ResponseError`
-    * `Mint.TransportError`
-    * `Mint.HTTPError`
+    * `Snap.HTTPClient.Error`
     * `Jason.DecodeError`
   """
   @callback get(path, params, headers, opts) :: result()
@@ -130,8 +140,7 @@ defmodule Snap.Cluster do
   * `{:ok, response}` - where response is a map representing the parsed JSON response.
   * `{:error, error}` - where the error can be a struct of either:
     * `Snap.ResponseError`
-    * `Mint.TransportError`
-    * `Mint.HTTPError`
+    * `Snap.HTTPClient.Error`
     * `Jason.DecodeError`
   """
   @callback post(path, body, params, headers, opts) :: result()
@@ -144,8 +153,7 @@ defmodule Snap.Cluster do
   * `{:ok, response}` - where response is a map representing the parsed JSON response.
   * `{:error, error}` - where the error can be a struct of either:
     * `Snap.ResponseError`
-    * `Mint.TransportError`
-    * `Mint.HTTPError`
+    * `Snap.HTTPClient.Error`
     * `Jason.DecodeError`
   """
   @callback put(path, body, params, headers, opts) :: result()
@@ -158,8 +166,7 @@ defmodule Snap.Cluster do
   * `{:ok, response}` - where response is a map representing the parsed JSON response.
   * `{:error, error}` - where the error can be a struct of either:
     * `Snap.ResponseError`
-    * `Mint.TransportError`
-    * `Mint.HTTPError`
+    * `Snap.HTTPClient.Error`
     * `Jason.DecodeError`
   """
   @callback delete(path, params, headers, opts) :: result()

--- a/lib/snap/exceptions/http_error.ex
+++ b/lib/snap/exceptions/http_error.ex
@@ -3,6 +3,8 @@ defmodule Snap.HTTPError do
   Represents an HTTP error returned while executing a query.
   """
 
+  alias Snap.HTTPClient
+
   @keys [
     :status,
     :body,
@@ -12,8 +14,8 @@ defmodule Snap.HTTPError do
   @enforce_keys @keys
   defexception @keys
 
-  def exception_from_response(%Finch.Response{status: status, body: body, headers: headers}) do
-    struct(__MODULE__, %{status: status, body: body, headers: headers})
+  def exception_from_response(%HTTPClient.Response{status: status, body: body, headers: headers}) do
+    %__MODULE__{status: status, body: body, headers: headers}
   end
 
   def message(%__MODULE__{} = e) do

--- a/lib/snap/http_client/adapters/finch.ex
+++ b/lib/snap/http_client/adapters/finch.ex
@@ -22,24 +22,28 @@ defmodule Snap.HTTPClient.Adapters.Finch do
   Available options for configuring the Finch adapter. For more information about the options,
   you can check [Finch's official docs](https://hexdocs.pm/finch/Finch.html#start_link/1-pool-configuration-options).
 
-    * `pool_size`: Set the pool size. Defaults to 5.
+    * `pool_size`: Set the pool size. Defaults to `5`.
+    * `conn_opts`: Connection options passed to `Mint.HTTP.connect/4`. Defaults to `[]`.
   """
   @type config :: [
-          pool_size: pos_integer()
+          pool_size: pos_integer(),
+          conn_opts: keyword()
         ]
 
   @default_pool_size 5
+  @default_conn_opts []
 
   @impl true
   def child_spec(config) do
     cluster = Keyword.fetch!(config, :cluster)
     url = Keyword.fetch!(config, :url)
     size = Keyword.get(config, :pool_size, @default_pool_size)
+    conn_opts = Keyword.get(config, :conn_opts, @default_conn_opts)
 
     finch_config = [
       name: connection_pool_name(cluster),
       pools: %{
-        url => [size: size, count: 1]
+        url => [size: size, count: 1, conn_opts: conn_opts]
       }
     ]
 

--- a/lib/snap/http_client/adapters/finch.ex
+++ b/lib/snap/http_client/adapters/finch.ex
@@ -1,11 +1,32 @@
 defmodule Snap.HTTPClient.Adapters.Finch do
   @moduledoc """
   Built in adapter using `Finch`.
+
+  You can also configure this adapter by explicitly setting the `http_client_adapter`
+  in the `Snap.Cluster` configuration with a tuple `{Snap.HTTPClient.Adapters.Finch, config}`.
+  For example:
+
+  ```
+  config :my_app, MyApp.Cluster,
+    http_client_adapter: {Snap.HTTPClient.Adapters.Finch, pool_size: 20}
+  ```
+
+  You can check the `t:config/0` for docs about the available configurations.
   """
   @behaviour Snap.HTTPClient
 
   alias Snap.HTTPClient.Error
   alias Snap.HTTPClient.Response
+
+  @typedoc """
+  Available options for configuring the Finch adapter. For more information about the options,
+  you can check [Finch's official docs](https://hexdocs.pm/finch/Finch.html#start_link/1-pool-configuration-options).
+
+    * `pool_size`: Set the pool size. Defaults to 5.
+  """
+  @type config :: [
+          pool_size: pos_integer()
+        ]
 
   @default_pool_size 5
 
@@ -39,7 +60,7 @@ defmodule Snap.HTTPClient.Adapters.Finch do
     response = %Response{
       headers: finch_response.headers,
       status: finch_response.status,
-      body: finch_response.body,
+      body: finch_response.body
     }
 
     {:ok, response}

--- a/lib/snap/http_client/adapters/finch.ex
+++ b/lib/snap/http_client/adapters/finch.ex
@@ -75,7 +75,7 @@ defmodule Snap.HTTPClient.Adapters.Finch do
   end
 
   defp handle_response({:error, origin}) do
-    {:error, Error.new(:unknown, origin)}
+    {:error, Error.unknown(origin)}
   end
 
   defp connection_pool_name(cluster) do

--- a/lib/snap/http_client/adapters/finch.ex
+++ b/lib/snap/http_client/adapters/finch.ex
@@ -1,0 +1,59 @@
+defmodule Snap.HTTPClient.Adapters.Finch do
+  @moduledoc """
+  Built in adapter using `Finch`.
+  """
+  @behaviour Snap.HTTPClient
+
+  alias Snap.HTTPClient.Error
+  alias Snap.HTTPClient.Response
+
+  @default_pool_size 5
+
+  @impl true
+  def child_spec(config) do
+    cluster = Keyword.fetch!(config, :cluster)
+    url = Keyword.fetch!(config, :url)
+    size = Keyword.get(config, :pool_size, @default_pool_size)
+
+    finch_config = [
+      name: connection_pool_name(cluster),
+      pools: %{
+        url => [size: size, count: 1]
+      }
+    ]
+
+    {Finch, finch_config}
+  end
+
+  @impl true
+  def request(cluster, method, url, headers, body, opts \\ []) do
+    conn_pool_name = connection_pool_name(cluster)
+
+    method
+    |> Finch.build(url, headers, body)
+    |> Finch.request(conn_pool_name, opts)
+    |> handle_response()
+  end
+
+  defp handle_response({:ok, %Finch.Response{} = finch_response}) do
+    response = %Response{
+      headers: finch_response.headers,
+      status: finch_response.status,
+      body: finch_response.body,
+    }
+
+    {:ok, response}
+  end
+
+  defp handle_response({:error, %{reason: reason} = origin}) when is_atom(reason) do
+    {:error, Error.new(reason, origin)}
+  end
+
+  defp handle_response({:error, origin}) do
+    {:error, Error.new(:unknown, origin)}
+  end
+
+  defp connection_pool_name(cluster) do
+    Module.concat(cluster, Pool)
+  end
+end

--- a/lib/snap/http_client/error.ex
+++ b/lib/snap/http_client/error.ex
@@ -29,6 +29,10 @@ defmodule Snap.HTTPClient.Error do
     %__MODULE__{reason: reason, origin: origin}
   end
 
+  def unknown(origin) do
+    new(:unknown, origin)
+  end
+
   @impl true
   def message(%__MODULE__{origin: origin}) when is_exception(origin) do
     Exception.message(origin)

--- a/lib/snap/http_client/error.ex
+++ b/lib/snap/http_client/error.ex
@@ -1,0 +1,40 @@
+defmodule Snap.HTTPClient.Error do
+  @moduledoc """
+  Represents an Error returned by the HTTPClient.
+
+  Usually this wraps an error coming from the adapter that implements the `Snap.HTTPClient` behaviour,
+  such as `Mint.HTTPError`.
+
+  ## Struct Fields
+
+    * `:reason` - the error reason represented by an atom.
+    * `:origin` - the origin of the error. Contains the original error coming from the adapter of the
+    `Snap.HTTPClient` behaviour, such as `Mint.HTTPError` or `Mint.TransportError`.
+  """
+
+  @keys [
+    :reason,
+    :origin,
+  ]
+
+  @enforce_keys @keys
+  defexception @keys
+
+  @type t :: %__MODULE__{
+          reason: atom(),
+          origin: any()
+        }
+
+  def new(reason, origin) when is_atom(reason) do
+    %__MODULE__{reason: reason, origin: origin}
+  end
+
+  @impl true
+  def message(%__MODULE__{origin: origin}) when is_exception(origin) do
+    Exception.message(origin)
+  end
+
+  def message(%__MODULE__{reason: reason}) do
+    to_string(reason)
+  end
+end

--- a/lib/snap/http_client/http_client.ex
+++ b/lib/snap/http_client/http_client.ex
@@ -10,6 +10,13 @@ defmodule Snap.HTTPClient do
   config :my_app, MyApp.Cluster,
     http_client_adapter: MyHTTPClientAdapter
   ```
+
+  The adapter can be configured passing a tuple:
+
+  ```
+  config :my_app, MyApp.Cluster,
+    http_client_adapter: {MyHTTPClientAdapter, some_config_for_adapter: "config_value"}
+  ```
   """
 
   alias Snap.HTTPClient.Error

--- a/lib/snap/http_client/http_client.ex
+++ b/lib/snap/http_client/http_client.ex
@@ -42,15 +42,22 @@ defmodule Snap.HTTPClient do
             ) :: {:ok, Response.t()} | {:error, Error.t()}
 
   def child_spec(config) do
-    adapter(config).child_spec(config)
+    {adapter, adapter_config} = adapter(config)
+
+    adapter.child_spec(config ++ adapter_config)
   end
 
   def request(cluster, method, url, headers, body, opts \\ []) do
-    adapter(cluster).request(cluster, method, url, headers, body, opts)
+    {adapter, _adapter_config} = adapter(cluster)
+
+    adapter.request(cluster, method, url, headers, body, opts)
   end
 
   defp adapter(cluster_config) when is_list(cluster_config) do
-    Keyword.get(cluster_config, :http_client_adapter, Snap.HTTPClient.Adapters.Finch)
+    case Keyword.get(cluster_config, :http_client_adapter, Snap.HTTPClient.Adapters.Finch) do
+      {adapter, config} -> {adapter, config}
+      adapter -> {adapter, []}
+    end
   end
 
   defp adapter(cluster) do

--- a/lib/snap/http_client/http_client.ex
+++ b/lib/snap/http_client/http_client.ex
@@ -23,7 +23,7 @@ defmodule Snap.HTTPClient do
   alias Snap.HTTPClient.Response
 
   @type t :: module()
-  @type method :: :get | :post | :put | :delete | String.t()
+  @type method :: :get | :post | :put | :delete
   @type url :: String.t()
   @type headers :: [{key :: String.t(), value :: String.t()}]
   @type body :: iodata()

--- a/lib/snap/http_client/http_client.ex
+++ b/lib/snap/http_client/http_client.ex
@@ -1,0 +1,59 @@
+defmodule Snap.HTTPClient do
+  @moduledoc """
+  Behaviour for the HTTP client used by the `Snap.Cluster`.
+
+  By default, it uses the `Snap.HTTPClient.Adapters.Finch` for making requests.
+
+  You can configure the Cluster with your own adapter:
+
+  ```
+  config :my_app, MyApp.Cluster,
+    http_client_adapter: MyHTTPClientAdapter
+  ```
+  """
+
+  alias Snap.HTTPClient.Error
+  alias Snap.HTTPClient.Response
+
+  @type t :: module()
+  @type method :: :get | :post | :put | :delete | String.t()
+  @type url :: String.t()
+  @type headers :: [{key :: String.t(), value :: String.t()}]
+  @type body :: iodata()
+  @type child_spec :: Supervisor.child_spec() | {module(), Keyword.t()} | module()
+
+  @doc """
+  Returns a specification to start this module under the `Snap` supervisor tree.
+
+  If the adapter doesn't need to start in the supervisor tree, you can return `:skip`.
+  """
+  @callback child_spec(config :: Keyword.t()) :: child_spec() | :skip
+
+  @doc """
+  Executes the request with the configured adapter.
+  """
+  @callback request(
+              cluster :: module(),
+              method :: atom(),
+              url,
+              headers,
+              body,
+              opts :: Keyword.t()
+            ) :: {:ok, Response.t()} | {:error, Error.t()}
+
+  def child_spec(config) do
+    adapter(config).child_spec(config)
+  end
+
+  def request(cluster, method, url, headers, body, opts \\ []) do
+    adapter(cluster).request(cluster, method, url, headers, body, opts)
+  end
+
+  defp adapter(cluster_config) when is_list(cluster_config) do
+    Keyword.get(cluster_config, :http_client_adapter, Snap.HTTPClient.Adapters.Finch)
+  end
+
+  defp adapter(cluster) do
+    adapter(cluster.config())
+  end
+end

--- a/lib/snap/http_client/response.ex
+++ b/lib/snap/http_client/response.ex
@@ -1,0 +1,21 @@
+defmodule Snap.HTTPClient.Response do
+  @moduledoc """
+  Response of a http request.
+  """
+
+  alias Snap.HTTPClient
+
+  defstruct [
+    :status,
+    body: "",
+    headers: []
+  ]
+
+  @type status :: non_neg_integer()
+
+  @type t :: %__MODULE__{
+          status: status(),
+          body: HTTPClient.body(),
+          headers: HTTPClient.headers()
+        }
+end

--- a/lib/snap/request.ex
+++ b/lib/snap/request.ex
@@ -37,7 +37,7 @@ defmodule Snap.Request do
 
       Logger.debug(fn ->
         """
-        Elasticsearch #{method} request \
+        Elasticsearch #{http_method_to_string(method)} request \
         path=#{path} \
         response=#{format_time_to_ms(response_time)}ms \
         decode=#{format_time_to_ms(decode_time)}ms \
@@ -65,7 +65,8 @@ defmodule Snap.Request do
 
   defp parse_response(response) do
     case response do
-      {:ok, %HTTPClient.Response{body: data, status: status}} when status >= 200 and status < 300 ->
+      {:ok, %HTTPClient.Response{body: data, status: status}}
+      when status >= 200 and status < 300 ->
         Jason.decode(data)
 
       {:ok, %HTTPClient.Response{body: data} = response} ->
@@ -95,7 +96,16 @@ defmodule Snap.Request do
   end
 
   defp telemetry_metadata(method, uri, _headers, body, result) do
-    %{method: method, host: uri.host, port: uri.port, path: uri.path, body: body, result: result}
+    method_str = http_method_to_string(method)
+
+    %{
+      method: method_str,
+      host: uri.host,
+      port: uri.port,
+      path: uri.path,
+      body: body,
+      result: result
+    }
   end
 
   defp encode_body(body) when is_map(body), do: Jason.encode!(body)
@@ -132,6 +142,12 @@ defmodule Snap.Request do
         List.keystore(acc, key, 0, tuple)
       end
     end)
+  end
+
+  defp http_method_to_string(method) when is_atom(method) do
+    method
+    |> Atom.to_string()
+    |> String.upcase()
   end
 
   defp format_time_to_ms(t) do

--- a/lib/snap/request.ex
+++ b/lib/snap/request.ex
@@ -1,8 +1,14 @@
 defmodule Snap.Request do
+  @moduledoc false
+
   require Logger
 
-  @moduledoc false
-  @default_headers [{"content-type", "application/json"}, {"accept", "application/json"}]
+  alias Snap.HTTPClient
+
+  @default_headers [
+    {"content-type", "application/json"},
+    {"accept", "application/json"}
+  ]
 
   def request(cluster, method, path, body \\ nil, params \\ [], headers \\ [], opts \\ []) do
     config = cluster.config()
@@ -17,14 +23,10 @@ defmodule Snap.Request do
     body = encode_body(body)
     headers = set_default_headers(headers)
 
-    conn_pool_name = Snap.Cluster.Supervisor.connection_pool_name(cluster)
-
     start_time = System.monotonic_time()
 
     with {:ok, {method, url, headers, body}} <- auth.sign(config, method, url, headers, body) do
-      response =
-        Finch.build(method, url, headers, body)
-        |> Finch.request(conn_pool_name, opts)
+      response = HTTPClient.request(cluster, method, url, headers, body, opts)
 
       response_time = System.monotonic_time() - start_time
 
@@ -34,7 +36,13 @@ defmodule Snap.Request do
       total_time = response_time + decode_time
 
       Logger.debug(fn ->
-        "Elasticsearch #{method} request path=#{path} response=#{format_time_to_ms(response_time)}ms decode=#{format_time_to_ms(decode_time)}ms total=#{format_time_to_ms(total_time)}ms"
+        """
+        Elasticsearch #{method} request \
+        path=#{path} \
+        response=#{format_time_to_ms(response_time)}ms \
+        decode=#{format_time_to_ms(decode_time)}ms \
+        total=#{format_time_to_ms(total_time)}ms\
+        """
       end)
 
       event = telemetry_prefix(cluster) ++ [:request]
@@ -57,10 +65,10 @@ defmodule Snap.Request do
 
   defp parse_response(response) do
     case response do
-      {:ok, %Finch.Response{body: data, status: status}} when status >= 200 and status < 300 ->
+      {:ok, %HTTPClient.Response{body: data, status: status}} when status >= 200 and status < 300 ->
         Jason.decode(data)
 
-      {:ok, %Finch.Response{body: data} = response} ->
+      {:ok, %HTTPClient.Response{body: data} = response} ->
         # If there's no valid JSON treat the error as an HTTPError.
         case Jason.decode(data) do
           {:ok, json} ->
@@ -72,7 +80,7 @@ defmodule Snap.Request do
             {:error, exception}
         end
 
-      err ->
+      {:error, %HTTPClient.Error{}} = err ->
         err
     end
   end
@@ -90,10 +98,7 @@ defmodule Snap.Request do
     %{method: method, host: uri.host, port: uri.port, path: uri.path, body: body, result: result}
   end
 
-  defp encode_body(body) when is_map(body) do
-    Jason.encode!(body)
-  end
-
+  defp encode_body(body) when is_map(body), do: Jason.encode!(body)
   defp encode_body(body), do: body
 
   def append_query_params(url, query_params \\ []) do

--- a/lib/snap/supervisor.ex
+++ b/lib/snap/supervisor.ex
@@ -2,8 +2,8 @@ defmodule Snap.Cluster.Supervisor do
   @moduledoc false
 
   use Supervisor
-  @default_pool_size 5
-  @default_conn_opts []
+
+  alias Snap.HTTPClient
 
   def start_link(cluster, otp_app, config) do
     Supervisor.start_link(__MODULE__, {cluster, otp_app, config}, name: cluster)
@@ -13,37 +13,29 @@ defmodule Snap.Cluster.Supervisor do
     Snap.Config.get(config_name(cluster))
   end
 
-  def connection_pool_name(cluster) do
-    Module.concat(cluster, Pool)
-  end
-
   ## Callbacks
 
   @doc false
   @impl Supervisor
   def init({cluster, _otp_app, config}) do
-    children = [
-      {Finch, finch_config(cluster, config)},
-      {Snap.Config, {config_name(cluster), config}}
-    ]
+    children =
+      [
+        {Snap.Config, {config_name(cluster), config}}
+      ] ++ maybe_initialize_http_client(cluster, config)
 
     Supervisor.init(children, strategy: :one_for_one)
   end
 
-  defp finch_config(cluster, config) do
-    url = Keyword.fetch!(config, :url)
-    size = Keyword.get(config, :pool_size, @default_pool_size)
-    conn_opts = Keyword.get(config, :conn_opts, @default_conn_opts)
-
-    [
-      name: connection_pool_name(cluster),
-      pools: %{
-        url => [size: size, count: 1, conn_opts: conn_opts]
-      }
-    ]
-  end
-
   defp config_name(cluster) do
     Module.concat(cluster, Config)
+  end
+
+  defp maybe_initialize_http_client(cluster, config) do
+    config = Keyword.put(config, :cluster, cluster)
+
+    case HTTPClient.child_spec(config) do
+      :skip -> []
+      http_client_child_spec -> [http_client_child_spec]
+    end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -15,6 +15,7 @@ defmodule Snap.MixProject do
       deps: deps(),
       dialyzer: dialyzer(),
       aliases: aliases(),
+      preferred_cli_env: ["test.all": :test],
 
       # Hex
       description: "A modern Elasticsearch client",
@@ -59,6 +60,7 @@ defmodule Snap.MixProject do
   defp aliases do
     [
       dev: "run --no-halt dev.exs",
+      "test.all": ["test --include integration"]
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -14,6 +14,7 @@ defmodule Snap.MixProject do
       elixirc_paths: elixirc_paths(Mix.env()),
       deps: deps(),
       dialyzer: dialyzer(),
+      aliases: aliases(),
 
       # Hex
       description: "A modern Elasticsearch client",
@@ -52,6 +53,12 @@ defmodule Snap.MixProject do
       {:ex_doc, "~> 0.23", only: :dev, runtime: false},
       {:dialyxir, "~> 1.0", only: :dev, runtime: false},
       {:credo, "~> 1.5", only: [:dev, :test], runtime: false}
+    ]
+  end
+
+  defp aliases do
+    [
+      dev: "run --no-halt dev.exs",
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -23,7 +23,14 @@ defmodule Snap.MixProject do
 
       # Docs
       source_url: @github_url,
-      docs: docs()
+      docs: docs(),
+
+      # Suppress warnings
+      xref: [
+        exclude: [
+          Finch
+        ]
+      ]
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -47,7 +47,7 @@ defmodule Snap.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:finch, "~> 0.8"},
+      {:finch, "~> 0.8", optional: true},
       {:castore, "~> 0.1"},
       {:jason, "~> 1.0"},
       {:telemetry, "~> 1.0"},

--- a/mix.exs
+++ b/mix.exs
@@ -84,6 +84,10 @@ defmodule Snap.MixProject do
           Snap.Auth,
           Snap.Auth.Plain
         ],
+        "HTTP Client": [
+          Snap.HTTPClient,
+          Snap.HTTPClient.Adapters.Finch
+        ],
         "Bulk operations": [
           Snap.Bulk.Action.Create,
           Snap.Bulk.Action.Index,
@@ -97,7 +101,8 @@ defmodule Snap.MixProject do
         ],
         Exceptions: [
           Snap.ResponseError,
-          Snap.BulkError
+          Snap.BulkError,
+          Snap.HTTPClient.Error
         ]
       ]
     ]

--- a/test/auth/plain_test.exs
+++ b/test/auth/plain_test.exs
@@ -1,5 +1,5 @@
 defmodule Snap.Auth.PlainTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
 
   alias Snap.Auth.Plain
 

--- a/test/auth/plain_test.exs
+++ b/test/auth/plain_test.exs
@@ -5,7 +5,7 @@ defmodule Snap.Auth.PlainTest do
 
   test "without a username and password in the config" do
     config = []
-    method = "GET"
+    method = :get
     path = "/_cluster/health"
     headers = []
     body = nil
@@ -19,7 +19,7 @@ defmodule Snap.Auth.PlainTest do
 
   test "with a username and password in the config" do
     config = [username: "testing", password: "password"]
-    method = "GET"
+    method = :get
     path = "/_cluster/health"
     headers = []
     body = nil
@@ -33,7 +33,7 @@ defmodule Snap.Auth.PlainTest do
 
   test "with a username and password in the config's URL" do
     config = [url: "http://testing:password@example.net:9200"]
-    method = "GET"
+    method = :get
     path = "/_cluster/health"
     headers = []
     body = nil

--- a/test/bulk/actions_test.exs
+++ b/test/bulk/actions_test.exs
@@ -1,5 +1,5 @@
 defmodule Snap.Bulk.ActionsTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
 
   alias Snap.Bulk.Action
   alias Snap.Bulk.Actions

--- a/test/http_client/adapters/finch_test.exs
+++ b/test/http_client/adapters/finch_test.exs
@@ -1,0 +1,108 @@
+defmodule Snap.HTTPClient.Adapters.FinchTest do
+  use ExUnit.Case, async: true
+
+  alias Snap.HTTPClient.Adapters.Finch, as: FinchAdapter
+  alias Snap.HTTPClient.Error
+  alias Snap.HTTPClient.Response
+
+  describe "child_spec/1" do
+    test "should set the default values for pool config" do
+      config = build_config()
+
+      assert {Finch,
+              [
+                name: Snap.Test.Cluster.Pool,
+                pools: %{"http://localhost:9200" => [size: 5, count: 1, conn_opts: []]}
+              ]} == FinchAdapter.child_spec(config)
+    end
+
+    test "should be able to configure pool_size" do
+      config = build_config(pool_size: 99)
+
+      assert {Finch, received_finch_config} = FinchAdapter.child_spec(config)
+      assert 99 == received_finch_config[:pools]["http://localhost:9200"][:size]
+    end
+
+    test "should be able to configure conn_opts" do
+      config = build_config(conn_opts: [hostname: "test.hostname.com"])
+
+      assert {Finch, received_finch_config} = FinchAdapter.child_spec(config)
+
+      assert [hostname: "test.hostname.com"] ==
+               received_finch_config[:pools]["http://localhost:9200"][:conn_opts]
+    end
+
+    test "should raise if cluster is not provided" do
+      config = build_config() |> Keyword.delete(:cluster)
+
+      expected_message = ~s(key :cluster not found in: [url: "http://localhost:9200"])
+      assert_raise(KeyError, expected_message, fn -> FinchAdapter.child_spec(config) end)
+    end
+
+    test "should raise if url is not provided" do
+      config = build_config() |> Keyword.delete(:url)
+
+      expected_message = ~s(key :url not found in: [cluster: Snap.Test.Cluster])
+      assert_raise(KeyError, expected_message, fn -> FinchAdapter.child_spec(config) end)
+    end
+  end
+
+  describe "request/5" do
+    @describetag :integration
+
+    test "should return ok with status 200 when request is successful" do
+      cluster = Snap.Test.Cluster
+      method = :get
+      url = "http://localhost:9200/_cluster/health"
+      headers = []
+      body = nil
+
+      assert {:ok, %Response{} = response} =
+               FinchAdapter.request(cluster, method, url, headers, body)
+
+      assert 200 == response.status
+      assert is_list(response.headers)
+      assert is_binary(response.body)
+    end
+
+    test "should return ok with client error status if request is wrong" do
+      cluster = Snap.Test.Cluster
+      method = :get
+      url = "http://localhost:9200/wrong-path"
+      headers = []
+      body = nil
+
+      assert {:ok, %Response{} = response} =
+               FinchAdapter.request(cluster, method, url, headers, body)
+
+      assert 404 == response.status
+      assert is_list(response.headers)
+      assert is_binary(response.body)
+    end
+
+    test "should return error if request fails" do
+      cluster = Snap.Test.Cluster
+      method = :get
+      url = "http://localhost:9999/wrong-port"
+      headers = []
+      body = nil
+
+      assert {:error, %Error{} = error} =
+               FinchAdapter.request(cluster, method, url, headers, body)
+
+      assert %Error{
+               reason: :econnrefused,
+               origin: %Mint.TransportError{reason: :econnrefused}
+             } == error
+    end
+  end
+
+  defp build_config(extra_config \\ []) do
+    default_config = [
+      cluster: Snap.Test.Cluster,
+      url: "http://localhost:9200"
+    ]
+
+    Keyword.merge(default_config, extra_config)
+  end
+end

--- a/test/search_response_test.exs
+++ b/test/search_response_test.exs
@@ -1,5 +1,5 @@
 defmodule Snap.SearchResponseTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
 
   alias Snap.SearchResponse
 

--- a/test/snap_test.exs
+++ b/test/snap_test.exs
@@ -1,8 +1,9 @@
 defmodule SnapTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
 
   alias Snap.Test.Cluster
 
+  @tag :integration
   test "getting server status" do
     {:ok, %{"status" => status}} = Snap.get(Cluster, "/_cluster/health")
     assert not is_nil(status)

--- a/test/telemetry_test.exs
+++ b/test/telemetry_test.exs
@@ -1,8 +1,9 @@
 defmodule Snap.TelemetryTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
 
   alias Snap.Test.Cluster
 
+  @tag :integration
   test "telemetry is fired with a request" do
     log = fn event_name, measurements, metadata ->
       assert event_name == [:snap, :snap, :request]


### PR DESCRIPTION
First, congrats on this library! We are using in the company I work for and we quite like it :) 

This MR aims to provide a way for the user to setup his own HTTP client, when they don't want to use Finch. This is specially useful for testing with libs such as [mox](https://github.com/dashbitco/mox)

Besides that, I added two more things that can be useful:

- Added `mix test.all` to run all tests, including the Integration ones
- Added `mix dev` so we can enter IEx with a running dev environment: `iex -S mix dev`

This is a big change, so if you guys think that the lib should be kept simple, feel free to close this MR or create discussions :)