### PR TITLE
Handle HTTP errors with their own exception

### DIFF
--- a/lib/snap/bulk/bulk.ex
+++ b/lib/snap/bulk/bulk.ex
@@ -147,19 +147,19 @@ defmodule Snap.Bulk do
   end
 
   defp process_item(%{"create" => %{"error" => error} = item}) when is_map(error) do
-    Snap.ResponseError.exception_from_response(item)
+    Snap.ResponseError.exception_from_json(item)
   end
 
   defp process_item(%{"index" => %{"error" => error} = item}) when is_map(error) do
-    Snap.ResponseError.exception_from_response(item)
+    Snap.ResponseError.exception_from_json(item)
   end
 
   defp process_item(%{"update" => %{"error" => error} = item}) when is_map(error) do
-    Snap.ResponseError.exception_from_response(item)
+    Snap.ResponseError.exception_from_json(item)
   end
 
   defp process_item(%{"delete" => %{"error" => error} = item}) when is_map(error) do
-    Snap.ResponseError.exception_from_response(item)
+    Snap.ResponseError.exception_from_json(item)
   end
 
   defp process_item(_), do: nil

--- a/lib/snap/exceptions/http_error.ex
+++ b/lib/snap/exceptions/http_error.ex
@@ -1,0 +1,22 @@
+defmodule Snap.HTTPError do
+  @moduledoc """
+  Represents an HTTP error returned while executing a query.
+  """
+
+  @keys [
+    :status,
+    :body,
+    :headers
+  ]
+
+  @enforce_keys @keys
+  defexception @keys
+
+  def exception_from_response(%Finch.Response{status: status, body: body, headers: headers}) do
+    struct(__MODULE__, %{status: status, body: body, headers: headers})
+  end
+
+  def message(%__MODULE__{} = e) do
+    "HTTP status #{e.status}"
+  end
+end

--- a/lib/snap/exceptions/response_error.ex
+++ b/lib/snap/exceptions/response_error.ex
@@ -24,8 +24,8 @@ defmodule Snap.ResponseError do
           raw: map() | nil
         }
 
-  def exception_from_response(response) do
-    attrs = build(response)
+  def exception_from_json(json) do
+    attrs = build(json)
     struct(__MODULE__, attrs)
   end
 


### PR DESCRIPTION
If you make a request that's too large for ES, you'll get an HTTP status 413, with an empty body. This change allows this to bubble up to the user, rather than returning a Jason.DecodeError.