### PR TITLE
Adds additional aggregations to handle

### DIFF
--- a/lib/snap/aggregation.ex
+++ b/lib/snap/aggregation.ex
@@ -6,21 +6,30 @@ defmodule Snap.Aggregation do
   """
   defstruct ~w[
     buckets
+    doc_count
     doc_count_error_upper_bound
+    interval
     sum_other_doc_count
+    value
   ]a
 
   def new(response) do
     %__MODULE__{
       buckets: response["buckets"],
+      doc_count: response["doc_count"],
       doc_count_error_upper_bound: response["doc_count_error_upper_bound"],
-      sum_other_doc_count: response["sum_other_doc_count"]
+      interval: response["interval"],
+      sum_other_doc_count: response["sum_other_doc_count"],
+      value: response["value"],
     }
   end
 
   @type t :: %__MODULE__{
           buckets: list(map()),
+          doc_count: integer(),
           doc_count_error_upper_bound: integer(),
-          sum_other_doc_count: integer()
+          interval: integer(),
+          sum_other_doc_count: integer(),
+          value: integer(),
         }
 end

--- a/test/fixtures/search_response_agg.json
+++ b/test/fixtures/search_response_agg.json
@@ -15,6 +15,22 @@
       ],
       "doc_count_error_upper_bound": 0,
       "sum_other_doc_count": 0
+    },
+    "people": {
+      "value": 8
+    },
+    "things": {
+      "doc_count": 9
+    },
+    "histogram": {
+      "buckets": [
+        {
+          "doc_count": 10,
+          "key": 1647118800000,
+          "key_as_string": "2022-03-12T21:00:00.000Z"
+        }
+      ],
+      "interval": "30m"
     }
   },
   "hits": {

--- a/test/search_response_test.exs
+++ b/test/search_response_test.exs
@@ -50,12 +50,31 @@ defmodule Snap.SearchResponseTest do
       |> Jason.decode!()
 
     response = SearchResponse.new(json)
-    assert Enum.count(response.aggregations) == 1
+    assert Enum.count(response.aggregations) == 4
 
     assert response.aggregations["season_values"] == %Snap.Aggregation{
              buckets: [%{"doc_count" => 69406, "key" => "summer"}],
              doc_count_error_upper_bound: 0,
              sum_other_doc_count: 0
+           }
+
+    assert response.aggregations["people"] == %Snap.Aggregation{
+             value: 8
+           }
+
+    assert response.aggregations["things"] == %Snap.Aggregation{
+             doc_count: 9
+           }
+
+    assert response.aggregations["histogram"] == %Snap.Aggregation{
+             buckets: [
+               %{
+                 "doc_count" => 10,
+                 "key_as_string" => "2022-03-12T21:00:00.000Z",
+                 "key" => 1_647_118_800_000
+               }
+             ],
+             interval: "30m"
            }
   end
 end


### PR DESCRIPTION
This PR aims to support more aggregations, namely those that respond with `value`, `doc_count`, and in the case of histograms, `interval`.

It builds off of the great work from @gabrielpra1 in https://github.com/breakroom/snap/pull/6.