### PR TITLE
add telemetry 0.4 as backwards compatible option to mix.exs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -58,7 +58,7 @@ defmodule Snap.MixProject do
       {:finch, "~> 0.8", optional: true},
       {:castore, "~> 0.1"},
       {:jason, "~> 1.0"},
-      {:telemetry, "~> 1.0"},
+      {:telemetry, "~> 1.0 or ~> 0.4"},
       {:ex_doc, "~> 0.23", only: :dev, runtime: false},
       {:dialyxir, "~> 1.0", only: :dev, runtime: false},
       {:credo, "~> 1.5", only: [:dev, :test], runtime: false}


### PR DESCRIPTION
**Why:**
Telemetry 1.0 has no changes from version 0.4.3 and most libraries opt for the flixibility of having telemetry **1.0 or 0.4**

In their own words from telemetry changelog: 
> [1.0.0](https://github.com/elixir-telemetry/telemetry/tree/v1.0.0)
> There are no changes in the 1.0.0 release - it marks the stability of the API.

Allowing both versions makes adopting snap into projects much easier, as some libraries still require telemetry 0.4

