### PR TITLE
Permit nil body in HTTPClient.Request typespec

### DIFF
--- a/lib/snap/http_client/http_client.ex
+++ b/lib/snap/http_client/http_client.ex
@@ -26,7 +26,7 @@ defmodule Snap.HTTPClient do
   @type method :: :get | :post | :put | :delete
   @type url :: String.t()
   @type headers :: [{key :: String.t(), value :: String.t()}]
-  @type body :: iodata()
+  @type body :: iodata() | nil
   @type child_spec :: Supervisor.child_spec() | {module(), Keyword.t()} | module()
 
   @doc """


### PR DESCRIPTION
Using `Cluster.get(url)` passes a nil to `HTTPClient.Request` which fails strict typespec enforcement (e.g. when using Hammox):

```
     ** (EXIT from #PID<0.880.0>) an exception was raised:
         ** (Hammox.TypeMatchError) 
     5th argument value nil does not match 5th parameter's type Snap.HTTPClient.body().
       Value nil does not match type binary() | iolist().
```

This PR fixes this by permitting nil bodies in the typespec.