### PR TITLE
Define opts with default empty keyword list performing bulk

### DIFF
--- a/lib/snap/bulk/bulk.ex
+++ b/lib/snap/bulk/bulk.ex
@@ -60,7 +60,7 @@ defmodule Snap.Bulk do
           opts :: Keyword.t()
         ) ::
           :ok | Snap.Cluster.error() | {:error, Snap.BulkError.t()}
-  def perform(stream, cluster, index, opts) do
+  def perform(stream, cluster, index, opts \\ []) do
     {page_size, opts} = Keyword.pop(opts, :page_size, @default_page_size)
     {page_wait, opts} = Keyword.pop(opts, :page_wait, @default_page_wait)
     {max_errors, opts} = Keyword.pop(opts, :max_errors, nil)


### PR DESCRIPTION
Hi there! 👋 

All the options have defaults, so I think that we could safely define a default empty list for the options. Also, reading the `@doc` looks like it was the intention no? 😄 