### PR TITLE
Fix latest release version in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.8.0
+## 0.8.1
 
 - Upgrade `finch`, which allows use of `castore` 1.0
 - Set minimum Elixir version to 1.12


### PR DESCRIPTION
Fix typo in the changelog and set the latest version to v0.8.1