### PR TITLE
Table.Reader Support

### DIFF
--- a/lib/snap/responses/search_response.ex
+++ b/lib/snap/responses/search_response.ex
@@ -63,3 +63,29 @@ defmodule Snap.SearchResponse do
     def slice(_response), do: {:error, __MODULE__}
   end
 end
+
+if Code.ensure_loaded?(Table.Reader) do
+  defimpl Table.Reader, for: Snap.SearchResponse do
+    def init(result) do
+      # {:rows, %{{:athena, :column_infos} => result.metadata, columns: result.columns},
+      #  result.rows}
+      IO.puts("hi")
+      {:rows, %{columns: get_columns(result)}, get_rows(result)}
+    end
+
+    defp get_columns(response) do
+      if response.hits.hits |> Enum.empty?() do
+        []
+      else
+        (response.hits.hits |> Enum.fetch(0))[:source] |> Map.keys()
+      end
+    end
+
+    defp get_rows(response) do
+      response.hits.hits
+      |> Enum.map(fn hit ->
+        hit.source
+      end)
+    end
+  end
+end

--- a/lib/snap/responses/search_response.ex
+++ b/lib/snap/responses/search_response.ex
@@ -62,14 +62,12 @@ defmodule Snap.SearchResponse do
 
     def slice(_response), do: {:error, __MODULE__}
   end
+end
 
-  defimpl Table.Reader do
+if Code.ensure_loaded?(Table.Reader) do
+  defimpl Table.Reader, for: Snap.SearchResponse do
     def init(result) do
-      # {:rows, %{{:athena, :column_infos} => result.metadata, columns: result.columns},
-      #  result.rows}
-      IO.puts("hi")
       columns = get_columns(result)
-      IO.inspect(columns)
       rows = get_rows(result)
       {:rows, %{columns: columns}, rows}
     end

--- a/lib/snap/responses/search_response.ex
+++ b/lib/snap/responses/search_response.ex
@@ -77,14 +77,17 @@ if Code.ensure_loaded?(Table.Reader) do
       if response.hits.hits |> Enum.empty?() do
         []
       else
-        (response.hits.hits |> Enum.fetch(0))[:source] |> Map.keys()
+        hits = response.hits.hits
+        hits |> List.first() |> Map.fetch!(:source) |> Map.keys()
       end
     end
 
     defp get_rows(response) do
-      response.hits.hits
+      hits = response.hits.hits
+
+      hits
       |> Enum.map(fn hit ->
-        hit.source
+        hit.source |> Map.values()
       end)
     end
   end

--- a/lib/snap/responses/search_response.ex
+++ b/lib/snap/responses/search_response.ex
@@ -64,31 +64,32 @@ defmodule Snap.SearchResponse do
   end
 end
 
-if Code.ensure_loaded?(Table.Reader) do
-  defimpl Table.Reader, for: Snap.SearchResponse do
-    def init(result) do
-      # {:rows, %{{:athena, :column_infos} => result.metadata, columns: result.columns},
-      #  result.rows}
-      IO.puts("hi")
-      {:rows, %{columns: get_columns(result)}, get_rows(result)}
-    end
+defimpl Table.Reader, for: Snap.SearchResponse do
+  def init(result) do
+    # {:rows, %{{:athena, :column_infos} => result.metadata, columns: result.columns},
+    #  result.rows}
+    IO.puts("hi")
+    columns = get_columns(result)
+    IO.inspect(columns)
+    rows = get_rows(result)
+    {:rows, %{columns: columns}, rows}
+  end
 
-    defp get_columns(response) do
-      if response.hits.hits |> Enum.empty?() do
-        []
-      else
-        hits = response.hits.hits
-        hits |> List.first() |> Map.fetch!(:source) |> Map.keys()
-      end
-    end
-
-    defp get_rows(response) do
+  defp get_columns(response) do
+    if response.hits.hits |> Enum.empty?() do
+      []
+    else
       hits = response.hits.hits
-
-      hits
-      |> Enum.map(fn hit ->
-        hit.source |> Map.values()
-      end)
+      hits |> List.first() |> Map.fetch!(:source) |> Map.keys()
     end
+  end
+
+  defp get_rows(response) do
+    hits = response.hits.hits
+
+    hits
+    |> Enum.map(fn hit ->
+      hit.source |> Map.values()
+    end)
   end
 end

--- a/lib/snap/responses/search_response.ex
+++ b/lib/snap/responses/search_response.ex
@@ -62,34 +62,34 @@ defmodule Snap.SearchResponse do
 
     def slice(_response), do: {:error, __MODULE__}
   end
-end
 
-defimpl Table.Reader, for: Snap.SearchResponse do
-  def init(result) do
-    # {:rows, %{{:athena, :column_infos} => result.metadata, columns: result.columns},
-    #  result.rows}
-    IO.puts("hi")
-    columns = get_columns(result)
-    IO.inspect(columns)
-    rows = get_rows(result)
-    {:rows, %{columns: columns}, rows}
-  end
-
-  defp get_columns(response) do
-    if response.hits.hits |> Enum.empty?() do
-      []
-    else
-      hits = response.hits.hits
-      hits |> List.first() |> Map.fetch!(:source) |> Map.keys()
+  defimpl Table.Reader do
+    def init(result) do
+      # {:rows, %{{:athena, :column_infos} => result.metadata, columns: result.columns},
+      #  result.rows}
+      IO.puts("hi")
+      columns = get_columns(result)
+      IO.inspect(columns)
+      rows = get_rows(result)
+      {:rows, %{columns: columns}, rows}
     end
-  end
 
-  defp get_rows(response) do
-    hits = response.hits.hits
+    defp get_columns(response) do
+      if response.hits.hits |> Enum.empty?() do
+        []
+      else
+        hits = response.hits.hits
+        hits |> List.first() |> Map.fetch!(:source) |> Map.keys()
+      end
+    end
 
-    hits
-    |> Enum.map(fn hit ->
-      hit.source |> Map.values()
-    end)
+    defp get_rows(response) do
+      hits = response.hits.hits
+
+      hits
+      |> Enum.map(fn hit ->
+        hit.source |> Map.values()
+      end)
+    end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -56,6 +56,7 @@ defmodule Snap.MixProject do
   defp deps do
     [
       {:finch, "~> 0.8", optional: true},
+      {:table, "~> 0.1.2"},
       {:castore, "~> 1.0"},
       {:jason, "~> 1.0"},
       {:telemetry, "~> 1.0 or ~> 0.4"},

--- a/mix.lock
+++ b/mix.lock
@@ -18,5 +18,6 @@
   "nimble_options": {:hex, :nimble_options, "1.1.0", "3b31a57ede9cb1502071fade751ab0c7b8dbe75a9a4c2b5bbb0943a690b63172", [:mix], [], "hexpm", "8bbbb3941af3ca9acc7835f5655ea062111c9c27bcac53e004460dfd19008a99"},
   "nimble_parsec": {:hex, :nimble_parsec, "1.4.0", "51f9b613ea62cfa97b25ccc2c1b4216e81df970acd8e16e8d1bdc58fef21370d", [:mix], [], "hexpm", "9c565862810fb383e9838c1dd2d7d2c437b3d13b267414ba6af33e50d2d1cf28"},
   "nimble_pool": {:hex, :nimble_pool, "1.0.0", "5eb82705d138f4dd4423f69ceb19ac667b3b492ae570c9f5c900bb3d2f50a847", [:mix], [], "hexpm", "80be3b882d2d351882256087078e1b1952a28bf98d0a287be87e4a24a710b67a"},
+  "table": {:hex, :table, "0.1.2", "87ad1125f5b70c5dea0307aa633194083eb5182ec537efc94e96af08937e14a8", [:mix], [], "hexpm", "7e99bc7efef806315c7e65640724bf165c3061cdc5d854060f74468367065029"},
   "telemetry": {:hex, :telemetry, "1.2.1", "68fdfe8d8f05a8428483a97d7aab2f268aaff24b49e0f599faa091f1d4e7f61c", [:rebar3], [], "hexpm", "dad9ce9d8effc621708f99eac538ef1cbe05d6a874dd741de2e689c47feafed5"},
 }


### PR DESCRIPTION
This adds Table.Reader support.  With it, you can use the results from Snap.Search.search in livebook, or explorer eg.

```elixir
{:ok, results} = Snap.Search.search(Elastic, "products_new", %{query: %{match_all: %{}}, size: 2000})

Kino.Shorts.data_table(results)
```

```elixir
{:ok, results} = Snap.Search.search(Elastic, "products_new", %{query: %{match_all: %{}}, size: 2000})

Explorer.DataFrame.new(results)
```

