### PR TITLE
Make Hit type optional

### DIFF
--- a/lib/snap/responses/hit.ex
+++ b/lib/snap/responses/hit.ex
@@ -32,7 +32,7 @@ defmodule Snap.Hit do
 
   @type t :: %__MODULE__{
           index: String.t(),
-          type: String.t(),
+          type: String.t() | nil,
           id: String.t(),
           score: float() | nil,
           source: map() | nil,


### PR DESCRIPTION
Hi :) Thanks for the library, appreciate it a lot!

Unfortunately, one of the subtle problems I'm seeing with it is that [Elastic no longer support mapping types.](https://www.elastic.co/guide/en/elasticsearch/reference/current/removal-of-types.html), starting from 8.0.0. They're still required in Snap though, causing all sorts of trouble with mock and/or integration tests and, essentially, forcing us to be stuck with 7.17 version.

This fix eliminates it. I've tested it on private fork and it resolved our need. Should be relatively harmless too!