### PR TITLE
Support routing param in Bulk actions

### DIFF
--- a/lib/snap/bulk/action.ex
+++ b/lib/snap/bulk/action.ex
@@ -11,18 +11,24 @@ defmodule Snap.Bulk.Action.Create do
   @behaviour Snap.Bulk.Action
 
   @enforce_keys [:doc]
-  defstruct [:index, :id, :require_alias, :doc]
+  defstruct [:index, :id, :require_alias, :doc, :routing]
 
   @type t :: %__MODULE__{
           index: String.t() | nil,
           id: String.t() | nil,
           require_alias: boolean() | nil,
-          doc: map()
+          doc: map(),
+          routing: String.t() | nil
         }
 
   @doc false
-  def to_action_json(%__MODULE__{index: index, id: id, require_alias: require_alias}) do
-    values = %{_index: index, _id: id, require_alias: require_alias}
+  def to_action_json(%__MODULE__{
+        index: index,
+        id: id,
+        require_alias: require_alias,
+        routing: routing
+      }) do
+    values = %{_index: index, _id: id, require_alias: require_alias, routing: routing}
 
     values
     |> Enum.reject(&is_nil(elem(&1, 1)))
@@ -43,17 +49,23 @@ defmodule Snap.Bulk.Action.Delete do
   @behaviour Snap.Bulk.Action
 
   @enforce_keys [:id]
-  defstruct [:index, :id, :require_alias]
+  defstruct [:index, :id, :require_alias, :routing]
 
   @type t :: %__MODULE__{
           index: String.t() | nil,
           id: String.t(),
-          require_alias: boolean() | nil
+          require_alias: boolean() | nil,
+          routing: String.t() | nil
         }
 
   @doc false
-  def to_action_json(%__MODULE__{index: index, id: id, require_alias: require_alias}) do
-    values = %{_index: index, _id: id, require_alias: require_alias}
+  def to_action_json(%__MODULE__{
+        index: index,
+        id: id,
+        require_alias: require_alias,
+        routing: routing
+      }) do
+    values = %{_index: index, _id: id, require_alias: require_alias, routing: routing}
 
     values
     |> Enum.reject(&is_nil(elem(&1, 1)))
@@ -72,18 +84,24 @@ defmodule Snap.Bulk.Action.Index do
   @behaviour Snap.Bulk.Action
 
   @enforce_keys [:doc]
-  defstruct [:index, :id, :require_alias, :doc]
+  defstruct [:index, :id, :require_alias, :doc, :routing]
 
   @type t :: %__MODULE__{
           index: String.t() | nil,
           id: String.t() | nil,
           require_alias: boolean() | nil,
-          doc: map()
+          doc: map(),
+          routing: String.t() | nil
         }
 
   @doc false
-  def to_action_json(%__MODULE__{index: index, id: id, require_alias: require_alias}) do
-    values = %{_index: index, _id: id, require_alias: require_alias}
+  def to_action_json(%__MODULE__{
+        index: index,
+        id: id,
+        require_alias: require_alias,
+        routing: routing
+      }) do
+    values = %{_index: index, _id: id, require_alias: require_alias, routing: routing}
 
     values
     |> Enum.reject(&is_nil(elem(&1, 1)))
@@ -110,7 +128,8 @@ defmodule Snap.Bulk.Action.Update do
     :require_alias,
     :doc,
     :doc_as_upsert,
-    :script
+    :script,
+    :routing
   ]
 
   @type t :: %__MODULE__{
@@ -119,12 +138,18 @@ defmodule Snap.Bulk.Action.Update do
           require_alias: boolean() | nil,
           doc: map(),
           doc_as_upsert: boolean() | nil,
-          script: map() | nil
+          script: map() | nil,
+          routing: String.t() | nil
         }
 
   @doc false
-  def to_action_json(%__MODULE__{index: index, id: id, require_alias: require_alias}) do
-    values = %{_index: index, _id: id, require_alias: require_alias}
+  def to_action_json(%__MODULE__{
+        index: index,
+        id: id,
+        require_alias: require_alias,
+        routing: routing
+      }) do
+    values = %{_index: index, _id: id, require_alias: require_alias, routing: routing}
 
     values
     |> Enum.reject(&is_nil(elem(&1, 1)))

--- a/test/bulk/actions_test.exs
+++ b/test/bulk/actions_test.exs
@@ -9,9 +9,9 @@ defmodule Snap.Bulk.ActionsTest do
     doc = %{"foo" => "bar"}
 
     actions = [
-      %Action.Index{index: "foo", doc: doc},
+      %Action.Index{index: "foo", doc: doc, routing: "baz"},
       %Action.Create{index: "foo", doc: doc, require_alias: true},
-      %Action.Update{index: "foo", doc: doc, id: 2},
+      %Action.Update{index: "foo", doc: doc, id: 2, routing: "baz"},
       %Action.Delete{index: "foo", id: 1}
     ]
 
@@ -23,11 +23,11 @@ defmodule Snap.Bulk.ActionsTest do
       |> Enum.map(&Jason.decode!/1)
 
     assert lines == [
-             %{"index" => %{"_index" => "foo"}},
+             %{"index" => %{"_index" => "foo", "routing" => "baz"}},
              doc,
              %{"create" => %{"_index" => "foo", "require_alias" => true}},
              doc,
-             %{"update" => %{"_index" => "foo", "_id" => 2}},
+             %{"update" => %{"_index" => "foo", "_id" => 2, "routing" => "baz"}},
              %{"doc" => doc},
              %{"delete" => %{"_index" => "foo", "_id" => 1}}
            ]


### PR DESCRIPTION
This PR adds routing support to bulk actions (Create, Delete, Index, Update).
https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html