### PR TITLE
Add ability to update and fetch index the index mapping

### DIFF
--- a/lib/snap/indexes.ex
+++ b/lib/snap/indexes.ex
@@ -25,6 +25,24 @@ defmodule Snap.Indexes do
   end
 
   @doc """
+  Get an index's mapping.
+  """
+  @spec get_mapping(module(), String.t(), Keyword.t()) :: Snap.Cluster.result()
+  def get_mapping(cluster, index, opts \\ []) do
+    namespaced_index = Namespace.add_namespace_to_index(index, cluster)
+    Snap.get(cluster, "/#{namespaced_index}/_mapping", [], [], opts)
+  end
+
+  @doc """
+  Updates the given index's mapping.
+  """
+  @spec update_mapping(module(), String.t(), map(), Keyword.t()) :: Snap.Cluster.result()
+  def update_mapping(cluster, index, mapping, opts \\ []) do
+    namespaced_index = Namespace.add_namespace_to_index(index, cluster)
+    Snap.put(cluster, "/#{namespaced_index}/_mapping", mapping, [], [], opts)
+  end
+
+  @doc """
   Creates and loads a new index, switching the alias to it with zero-downtime.
 
   Takes an `Enumerable` of `Snap.Bulk` actions, and builds a new index from

--- a/test/indexes_test.exs
+++ b/test/indexes_test.exs
@@ -4,6 +4,7 @@ defmodule Snap.IndexesTest do
 
   alias Snap
   alias Snap.Bulk.Action.Create
+  alias Snap.Cluster.Namespace
   alias Snap.Document
   alias Snap.Indexes
   alias Snap.Search
@@ -35,6 +36,16 @@ defmodule Snap.IndexesTest do
     assert {:ok, _} = Document.index(Cluster, index, %{foo: "bar"}, 1)
     assert :ok = Indexes.alias(Cluster, index, alias)
     assert {:ok, _} = Document.get(Cluster, alias, 1)
+  end
+
+  test "update an indices mapping" do
+    mapping = %{"properties" => %{"test" => %{"type" => "text"}}}
+
+    assert {:ok, _} = Indexes.create(Cluster, @test_index, %{})
+    assert {:ok, _} = Indexes.update_mapping(Cluster, @test_index, mapping)
+    assert {:ok, result} = Indexes.get_mapping(Cluster, @test_index)
+    index = Namespace.add_namespace_to_index(@test_index, Cluster)
+    assert result[index]["mappings"] == mapping
   end
 
   test "hotswap loading 10,000 documents" do


### PR DESCRIPTION
I need the ability to fetch these mappings and update them and would like to do this without resorting to cobbling together the namespacing with the index name for my tests. This seemed pretty straightforward and the right place to put this.