### PR TITLE
Implement Process Namespace for Process Ancestors

### DIFF
--- a/test/namespace_test.exs
+++ b/test/namespace_test.exs
@@ -65,6 +65,13 @@ defmodule Snap.Cluster.NamespaceTest do
       assert "cluster-process-index" ==
                Namespace.add_namespace_to_index("index", NamespaceCluster)
 
+      task =
+        Task.async(fn ->
+          Namespace.add_namespace_to_index("index", NamespaceCluster)
+        end)
+
+      assert "cluster-process-index" == Task.await(task)
+
       Namespace.clear_process_namespace(NamespaceCluster, self())
       assert "cluster-index" == Namespace.add_namespace_to_index("index", NamespaceCluster)
     end


### PR DESCRIPTION
When using `Snap.Cluster.Namespace` in tests and the project is using `Task` or things like `Phoenix.LiveView.assign_async/4`, the namespace is not correctly detected.

This change will traverse the current process `$ancestors` to detect if a parent process has a custom namespace set.