### PR TITLE
Add request + response body bytes to telemetry measurements

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.17.1-otp-27
-erlang 27.0
+elixir 1.17.3-otp-27
+erlang 27.1.2

--- a/test/telemetry_test.exs
+++ b/test/telemetry_test.exs
@@ -22,6 +22,9 @@ defmodule Snap.TelemetryTest do
       assert measurements.total_time ==
                measurements.response_time + measurements.decode_time
 
+      assert measurements.request_body_bytes == 0
+      assert measurements.response_body_bytes > 0
+
       send(self(), :logged)
     end
 


### PR DESCRIPTION
It's useful to be able to track the size of the HTTP requests and responses, so added these to the telemetry measurements.