### PR TITLE
Enable Finch pool metrics

### DIFF
--- a/lib/snap/http_client/adapters/finch.ex
+++ b/lib/snap/http_client/adapters/finch.ex
@@ -66,7 +66,7 @@ defmodule Snap.HTTPClient.Adapters.Finch do
     finch_config = [
       name: connection_pool_name(cluster),
       pools: %{
-        url => [size: size, count: 1, conn_opts: conn_opts]
+        url => [size: size, count: 1, conn_opts: conn_opts, start_pool_metrics?: true]
       }
     ]
 

--- a/test/http_client/adapters/finch_test.exs
+++ b/test/http_client/adapters/finch_test.exs
@@ -13,7 +13,14 @@ defmodule Snap.HTTPClient.Adapters.FinchTest do
       assert {Finch,
               [
                 name: Snap.Test.Cluster.Pool,
-                pools: %{"http://localhost:9200" => [size: 5, count: 1, conn_opts: []]}
+                pools: %{
+                  "http://localhost:9200" => [
+                    size: 5,
+                    count: 1,
+                    conn_opts: [],
+                    start_pool_metrics?: true
+                  ]
+                }
               ]} == FinchAdapter.child_spec(config)
     end
 
@@ -96,6 +103,11 @@ defmodule Snap.HTTPClient.Adapters.FinchTest do
                origin: %Mint.TransportError{reason: :econnrefused}
              } == error
     end
+  end
+
+  test "should be able to retreive Finch pool metrics" do
+    assert {:ok, [%Finch.HTTP1.PoolMetrics{}]} =
+             Finch.get_pool_status(Snap.Test.Cluster.Pool, {:http, "localhost", 9200})
   end
 
   defp build_config(extra_config \\ []) do


### PR DESCRIPTION
Add a `start_pool_metrics?: true` option to the Finch pool configuration.

`Finch.get_pool_status/2` can then return HTTP client connection pool metrics. For example:

    > Finch.get_pool_status(Snap.Test.Cluster.Pool, {:http, "localhost", 9200})
    {:ok,
     [
       %Finch.HTTP1.PoolMetrics{
         pool_index: 1,
         pool_size: 5,
         available_connections: 5,
         in_use_connections: 0
        }
      ]}