### PR TITLE
Revert "Implement Process Namespace for Process Ancestors"

### DIFF
--- a/lib/snap/namespace.ex
+++ b/lib/snap/namespace.ex
@@ -152,7 +152,9 @@ defmodule Snap.Cluster.Namespace do
 
   @doc false
   def handle_call({:get, pid}, _from, state) do
-    {:reply, get_namespace_recursive(state, pid), state}
+    namespace = Map.get(state, pid)
+
+    {:reply, namespace, state}
   end
 
   @doc false
@@ -162,29 +164,6 @@ defmodule Snap.Cluster.Namespace do
     state = Map.delete(state, pid)
 
     {:noreply, state}
-  end
-
-  @spec get_namespace_recursive(state :: %{pid() => String.t()}, process :: pid()) ::
-          String.t() | nil
-  defp get_namespace_recursive(state, process) do
-    case Map.fetch(state, process) do
-      {:ok, namespace} ->
-        namespace
-
-      :error ->
-        case Process.info(process, {:dictionary, :"$ancestors"}) do
-          {{:dictionary, :"$ancestors"}, :undefined} ->
-            nil
-
-          {{:dictionary, :"$ancestors"}, ancestors} ->
-            ancestors
-            |> Enum.map(&GenServer.whereis/1)
-            |> Enum.find_value(&get_namespace_recursive(state, &1))
-
-          nil ->
-            nil
-        end
-    end
   end
 
   defp config_namespace(cluster) do

--- a/test/namespace_test.exs
+++ b/test/namespace_test.exs
@@ -65,13 +65,6 @@ defmodule Snap.Cluster.NamespaceTest do
       assert "cluster-process-index" ==
                Namespace.add_namespace_to_index("index", NamespaceCluster)
 
-      task =
-        Task.async(fn ->
-          Namespace.add_namespace_to_index("index", NamespaceCluster)
-        end)
-
-      assert "cluster-process-index" == Task.await(task)
-
       Namespace.clear_process_namespace(NamespaceCluster, self())
       assert "cluster-index" == Namespace.add_namespace_to_index("index", NamespaceCluster)
     end


### PR DESCRIPTION
Reverts breakroom/snap#130 - this is causing issues with the test environment that need closer looking at.