### PR TITLE
Add support for completion suggests

### DIFF
--- a/lib/snap/responses/suggest/option.ex
+++ b/lib/snap/responses/suggest/option.ex
@@ -4,21 +4,30 @@ defmodule Snap.Suggest.Option do
   """
   defstruct ~w[
     freq
+    id
+    index
     score
+    source
     text
   ]a
 
   def new(response) do
     %__MODULE__{
       freq: response["freq"],
-      score: response["score"],
+      id: response["_id"],
+      index: response["_index"],
+      score: response["score"] || response["_score"],
+      source: response["_source"],
       text: response["text"]
     }
   end
 
   @type t :: %__MODULE__{
           freq: integer(),
+          id: String.t() | nil,
+          index: String.t() | nil,
           score: float(),
+          source: map() | nil,
           text: String.t()
         }
 end

--- a/test/search_test.exs
+++ b/test/search_test.exs
@@ -54,8 +54,17 @@ defmodule Snap.SearchTest do
     assert first_hit.source["title"] == "Document 1"
 
     assert %Snap.SearchResponse{
-             suggest: %{"title" => [%{text: "doument", options: [%{text: "document"}]}]}
+             suggest: %{
+               "title" => [
+                 %Snap.Suggest{
+                   text: "doument",
+                   options: [%Snap.Suggest.Option{freq: 5, text: "document", score: score}]
+                 }
+               ]
+             }
            } = search_response
+
+    assert is_float(score)
   end
 
   test "count/2 without a query" do

--- a/test/search_test.exs
+++ b/test/search_test.exs
@@ -67,6 +67,69 @@ defmodule Snap.SearchTest do
     assert is_float(score)
   end
 
+  test "search with an autocomplete response" do
+    {:ok, _} =
+      Snap.Indexes.create(Cluster, @test_index, %{
+        mappings: %{
+          properties: %{
+            name: %{
+              type: "completion"
+            }
+          }
+        }
+      })
+
+    [
+      %Action.Index{id: 1, doc: %{name: "Cat"}},
+      %Action.Index{id: 2, doc: %{name: "Caracal"}},
+      %Action.Index{id: 3, doc: %{name: "Dog"}}
+    ]
+    |> Snap.Bulk.perform(Cluster, @test_index, refresh: true)
+
+    query = %{
+      suggest: %{
+        autocomplete: %{
+          prefix: "ca",
+          completion: %{
+            field: "name"
+          }
+        }
+      }
+    }
+
+    {:ok, search_response} = Search.search(Cluster, @test_index, query)
+
+    assert %Snap.SearchResponse{
+             suggest: %{
+               "autocomplete" => [
+                 %Snap.Suggest{
+                   text: "ca",
+                   options: [
+                     %Snap.Suggest.Option{
+                       id: "2",
+                       text: "Caracal",
+                       score: caracal_score,
+                       index: index,
+                       source: %{"name" => "Caracal"}
+                     },
+                     %Snap.Suggest.Option{
+                       id: "1",
+                       text: "Cat",
+                       score: cat_score,
+                       index: index,
+                       source: %{"name" => "Cat"}
+                     }
+                   ]
+                 }
+               ]
+             }
+           } = search_response
+
+    assert is_float(caracal_score)
+    assert is_float(cat_score)
+    assert is_binary(index)
+  end
+
   test "count/2 without a query" do
     {:ok, _} = Snap.Indexes.create(Cluster, @test_index, %{})
     {:ok, _} = Snap.Document.add(Cluster, @test_index, %{foo: "bar"})


### PR DESCRIPTION
When using a completion suggester via the `search` endpoint three additional fields are returned in each option; `id`, `index` and `source`.

Update the `Snap.Suggest.Option` struct so that these fields are represented making sure that `score` is supported with an underscored and non-underscored key.

Docs: https://opensearch.org/docs/latest/search-plugins/searching-data/autocomplete/#completion-suggester