### PR TITLE
Inherit process namespaces from ancestors

### DIFF
--- a/lib/snap/supervisor.ex
+++ b/lib/snap/supervisor.ex
@@ -13,10 +13,6 @@ defmodule Snap.Cluster.Supervisor do
     Snap.Config.get(config_name(cluster))
   end
 
-  def namespace_pid(cluster) do
-    namespace_name(cluster)
-  end
-
   ## Callbacks
 
   @doc false
@@ -24,8 +20,7 @@ defmodule Snap.Cluster.Supervisor do
   def init({cluster, _otp_app, config}) do
     children =
       [
-        {Snap.Config, {config_name(cluster), config}},
-        {Snap.Cluster.Namespace, namespace_name(cluster)}
+        {Snap.Config, {config_name(cluster), config}}
       ] ++ maybe_initialize_http_client(cluster, config)
 
     Supervisor.init(children, strategy: :one_for_one)
@@ -33,10 +28,6 @@ defmodule Snap.Cluster.Supervisor do
 
   defp config_name(cluster) do
     Module.concat(cluster, Config)
-  end
-
-  defp namespace_name(cluster) do
-    Module.concat(cluster, Namespace)
   end
 
   defp maybe_initialize_http_client(cluster, config) do

--- a/mix.exs
+++ b/mix.exs
@@ -58,6 +58,7 @@ defmodule Snap.MixProject do
       {:finch, "~> 0.17", optional: true},
       {:castore, "~> 1.0"},
       {:jason, "~> 1.0"},
+      {:process_tree, "~> 0.2"},
       {:telemetry, "~> 1.0 or ~> 0.4"},
       {:ex_doc, "~> 0.23", only: :dev, runtime: false},
       {:dialyxir, "~> 1.0", only: :dev, runtime: false},

--- a/mix.lock
+++ b/mix.lock
@@ -18,5 +18,6 @@
   "nimble_options": {:hex, :nimble_options, "1.1.1", "e3a492d54d85fc3fd7c5baf411d9d2852922f66e69476317787a7b2bb000a61b", [:mix], [], "hexpm", "821b2470ca9442c4b6984882fe9bb0389371b8ddec4d45a9504f00a66f650b44"},
   "nimble_parsec": {:hex, :nimble_parsec, "1.4.0", "51f9b613ea62cfa97b25ccc2c1b4216e81df970acd8e16e8d1bdc58fef21370d", [:mix], [], "hexpm", "9c565862810fb383e9838c1dd2d7d2c437b3d13b267414ba6af33e50d2d1cf28"},
   "nimble_pool": {:hex, :nimble_pool, "1.1.0", "bf9c29fbdcba3564a8b800d1eeb5a3c58f36e1e11d7b7fb2e084a643f645f06b", [:mix], [], "hexpm", "af2e4e6b34197db81f7aad230c1118eac993acc0dae6bc83bac0126d4ae0813a"},
+  "process_tree": {:hex, :process_tree, "0.2.1", "4ebcaa96c64a7833467909f49fee28a8e62eed04975613f4c81b4b99424f7e8a", [:mix], [], "hexpm", "68eee6bf0514351aeeda7037f1a6003c0e25de48fe6b7d15a1b0aebb4b35e713"},
   "telemetry": {:hex, :telemetry, "1.3.0", "fedebbae410d715cf8e7062c96a1ef32ec22e764197f70cda73d82778d61e7a2", [:rebar3], [], "hexpm", "7015fc8919dbe63764f4b4b87a95b7c0996bd539e0d499be6ec9d7f3875b79e6"},
 }

--- a/test/namespace_test.exs
+++ b/test/namespace_test.exs
@@ -50,12 +50,12 @@ defmodule Snap.Cluster.NamespaceTest do
     end
   end
 
-  describe "set_process_namespace/3 and clear_process_namespace/2" do
+  describe "set_process_namespace/2 and clear_process_namespace/1" do
     test "without a cluster index_namespace" do
       Namespace.set_process_namespace(NoNamespaceCluster, "process")
       assert "process-index" == Namespace.add_namespace_to_index("index", NoNamespaceCluster)
 
-      Namespace.clear_process_namespace(NoNamespaceCluster, self())
+      Namespace.clear_process_namespace(NoNamespaceCluster)
       assert "index" == Namespace.add_namespace_to_index("index", NoNamespaceCluster)
     end
 
@@ -65,7 +65,7 @@ defmodule Snap.Cluster.NamespaceTest do
       assert "cluster-process-index" ==
                Namespace.add_namespace_to_index("index", NamespaceCluster)
 
-      Namespace.clear_process_namespace(NamespaceCluster, self())
+      Namespace.clear_process_namespace(NamespaceCluster)
       assert "cluster-index" == Namespace.add_namespace_to_index("index", NamespaceCluster)
     end
   end

--- a/test/support/integration_case.ex
+++ b/test/support/integration_case.ex
@@ -9,7 +9,7 @@ defmodule Snap.IntegrationCase do
 
   # Clean out any indexes remaining after each test run
   setup do
-    namespace = Test.generate_namespace_for_pid(self())
+    namespace = Test.generate_namespace()
     Namespace.set_process_namespace(Cluster, namespace)
     Test.drop_indexes(Cluster)
 


### PR DESCRIPTION
During testing sometimes it's not possible to get a handle on a process before some aspect of the test has run. This is true of LiveViews, which are spawned with `{:ok, view, _html} = live(conn, ~p"/some/path")` and are already rendered by the time we have a handle on the `view` process. Any Snap calls during `mount/3` or `handle_params/3` have no process namespace set.

To make this kind of thing easier to test, we now use process namespaces to persist the namespace, and walk up the process tree to find any namespaces defined on parent processes. We use ProcessTree, which handles some of the complexity of walking the tree and the behaviour of different OTP versions.

This introduces a breaking change around testing, with the removal of the namespacing functions that take an explicit `pid`, as it's not possible to set a value in a process dictionary in a process different to the currently running one. Thankfully I don't think this is a very common use case, and the testing API still hangs together nicely.

If you've implemented our suggested setup block, you'll need to make a small change:

```diff
  setup context do
    if context[:snap] do
-     namespace = Snap.Test.generate_namespace_for_pid(self())
+     namespace = Snap.Test.generate_namespace()
      Snap.Cluster.Namespace.set_process_namespace(Cluster, namespace)
      Snap.Test.drop_indexes(Cluster)

      on_exit(fn ->
        Snap.Cluster.Namespace.set_process_namespace(Cluster, namespace)
        Snap.Test.drop_indexes(Cluster)
      end)
    end
  end
```