### PR TITLE
Fix directory traversal attack

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
             search: elasticsearch-7.6.0
           - elixir: 1.18.x
             otp: 27.x
-            search: elasticsearch-8.2.0
+            search: elasticsearch-8.19.14
           - elixir: 1.18.x
             otp: 27.x
             search: opensearch-2.6.0

--- a/lib/snap/exceptions/invalid_path_error.ex
+++ b/lib/snap/exceptions/invalid_path_error.ex
@@ -1,0 +1,25 @@
+defmodule Snap.InvalidPathError do
+  @moduledoc """
+  Represents an error when a request path is malformed or contains
+  directory-traversal segments.
+  """
+
+  @enforce_keys [:path]
+  defexception [:path, :message]
+
+  @type t :: %__MODULE__{
+          path: term(),
+          message: String.t()
+        }
+
+  @impl true
+  def exception(opts) when is_list(opts) do
+    path = Keyword.fetch!(opts, :path)
+
+    message =
+      "request path #{inspect(path)} is invalid: it contains traversal " <>
+        "segments (`..` or `.`) or is not an absolute path"
+
+    %__MODULE__{path: path, message: message}
+  end
+end

--- a/lib/snap/request.ex
+++ b/lib/snap/request.ex
@@ -85,7 +85,9 @@ defmodule Snap.Request do
   end
 
   defp validate_path("/" <> path = raw_path) do
-    segments = String.split(path, "/")
+    # Decode before splitting so percent-encoded variants like `%2E%2E` or
+    # `%2F..%2F` can't smuggle traversal past the segment check.
+    segments = path |> URI.decode() |> String.split("/")
 
     if Enum.any?(segments, &(&1 in ["..", ".", ""])) do
       {:error, Snap.InvalidPathError.exception(path: raw_path)}

--- a/lib/snap/request.ex
+++ b/lib/snap/request.ex
@@ -18,6 +18,12 @@ defmodule Snap.Request do
   Makes an HTTP request against a `Snap.Cluster`
   """
   def request(cluster, method, path, body \\ nil, params \\ [], headers \\ [], opts \\ []) do
+    with :ok <- validate_path(path) do
+      do_request(cluster, method, path, body, params, headers, opts)
+    end
+  end
+
+  defp do_request(cluster, method, path, body, params, headers, opts) do
     config = cluster.config()
     auth = Keyword.get(config, :auth, Snap.Auth.Plain)
     json_library = cluster.json_library()
@@ -25,7 +31,8 @@ defmodule Snap.Request do
     url =
       config
       |> Keyword.fetch!(:url)
-      |> URI.merge(path)
+      |> URI.parse()
+      |> URI.append_path(path)
       |> append_query_params(params)
 
     body = encode_body(body, json_library)
@@ -75,6 +82,20 @@ defmodule Snap.Request do
 
       result
     end
+  end
+
+  defp validate_path("/" <> path = raw_path) do
+    segments = String.split(path, "/")
+
+    if Enum.any?(segments, &(&1 in ["..", ".", ""])) do
+      {:error, Snap.InvalidPathError.exception(path: raw_path)}
+    else
+      :ok
+    end
+  end
+
+  defp validate_path(path) do
+    {:error, Snap.InvalidPathError.exception(path: path)}
   end
 
   defp parse_response(response, json_library) do

--- a/test/request_test.exs
+++ b/test/request_test.exs
@@ -1,5 +1,5 @@
 defmodule Snap.RequestTest do
-  use ExUnit.Case, async: true
+  use Snap.IntegrationCase, async: true
 
   alias Snap.Request
   alias Snap.Test.Cluster
@@ -39,6 +39,46 @@ defmodule Snap.RequestTest do
       {:error, error} = Request.request(Cluster, :get, "/a/../b")
       assert Exception.message(error) =~ "/a/../b"
       assert Exception.message(error) =~ "traversal"
+    end
+
+    test "rejects percent-encoded `..` segments" do
+      assert {:error, %Snap.InvalidPathError{}} =
+               Request.request(Cluster, :get, "/users/_doc/%2E%2E/_all")
+
+      assert {:error, %Snap.InvalidPathError{}} =
+               Request.request(Cluster, :get, "/users/_doc/%2e%2e/_all")
+    end
+
+    test "rejects percent-encoded `.` segments" do
+      assert {:error, %Snap.InvalidPathError{}} =
+               Request.request(Cluster, :get, "/users/%2E/_doc/1")
+
+      assert {:error, %Snap.InvalidPathError{}} =
+               Request.request(Cluster, :get, "/users/%2e/_doc/1")
+    end
+
+    test "rejects percent-encoded slashes that smuggle traversal segments" do
+      assert {:error, %Snap.InvalidPathError{}} =
+               Request.request(Cluster, :get, "/users/_doc/x%2F..%2F..%2F_all")
+
+      assert {:error, %Snap.InvalidPathError{}} =
+               Request.request(Cluster, :get, "/users/_doc/x%2f..%2f..%2f_all")
+    end
+
+    test "rejects percent-encoded slash adjacent to a literal slash" do
+      assert {:error, %Snap.InvalidPathError{}} =
+               Request.request(Cluster, :get, "/users/%2F/_doc/1")
+    end
+
+    test "allows legitimate percent-encoded characters that aren't traversal" do
+      # A percent-encoded space decodes to " ", which is a legal path segment.
+      # We can't easily assert success without hitting Elasticsearch, but we
+      # can at least confirm the path validator does not short-circuit with an
+      # InvalidPathError.
+      refute match?(
+               {:error, %Snap.InvalidPathError{}},
+               Request.request(Cluster, :get, "/users/_doc/hello%20world")
+             )
     end
   end
 end

--- a/test/request_test.exs
+++ b/test/request_test.exs
@@ -1,0 +1,44 @@
+defmodule Snap.RequestTest do
+  use ExUnit.Case, async: true
+
+  alias Snap.Request
+  alias Snap.Test.Cluster
+
+  describe "path validation" do
+    test "rejects `..` traversal in the path" do
+      assert {:error, %Snap.InvalidPathError{path: "/users/_doc/x/../../_all"}} =
+               Request.request(Cluster, :delete, "/users/_doc/x/../../_all")
+    end
+
+    test "rejects leading `..` in the path" do
+      assert {:error, %Snap.InvalidPathError{path: "/../foo"}} =
+               Request.request(Cluster, :get, "/../foo")
+    end
+
+    test "rejects `.` segments" do
+      assert {:error, %Snap.InvalidPathError{}} =
+               Request.request(Cluster, :get, "/users/./_doc/1")
+    end
+
+    test "rejects protocol-relative paths that would redirect to another host" do
+      assert {:error, %Snap.InvalidPathError{path: "//evil.com/_doc"}} =
+               Request.request(Cluster, :get, "//evil.com/_doc")
+    end
+
+    test "rejects paths that are not absolute" do
+      assert {:error, %Snap.InvalidPathError{path: "users/_doc/1"}} =
+               Request.request(Cluster, :get, "users/_doc/1")
+    end
+
+    test "rejects non-binary paths" do
+      assert {:error, %Snap.InvalidPathError{path: nil}} =
+               Request.request(Cluster, :get, nil)
+    end
+
+    test "exposes the offending path in the exception message" do
+      {:error, error} = Request.request(Cluster, :get, "/a/../b")
+      assert Exception.message(error) =~ "/a/../b"
+      assert Exception.message(error) =~ "traversal"
+    end
+  end
+end


### PR DESCRIPTION
If a caller-supplied document ID or path contains `..` or `.` segments, it's possible to use this to traverse to a different path than intended. For example, a document ID of `x/../../_all` would cause the request to be sent to `/{index}/_doc/x/../../_all`, which is resolved to `/_all`.

Fix this in `Snap.Request` by validating the path before sending the request, and rejecting any paths that contain traversal segments or are not absolute with a `Snap.InvalidPathError` error tuple.