### PR TITLE
Escape path segments in document and index APIs

### DIFF
--- a/lib/snap/document.ex
+++ b/lib/snap/document.ex
@@ -4,37 +4,41 @@ defmodule Snap.Document do
   """
 
   alias Snap.Cluster.Namespace
+  alias Snap.Request
 
   @doc """
   Gets a document in the index with the specified ID
   """
   def get(cluster, index, id, params \\ [], opts \\ []) do
-    namespaced_index = Namespace.add_namespace_to_index(index, cluster)
-    Snap.get(cluster, "/#{namespaced_index}/_doc/#{id}", params, [], opts)
+    index = index |> Namespace.add_namespace_to_index(cluster) |> Request.encode_segment()
+    id = Request.encode_segment(id)
+    Snap.get(cluster, "/#{index}/_doc/#{id}", params, [], opts)
   end
 
   @doc """
   Creates a document in the index with the specified ID. Fails if a document already exists at that ID.
   """
   def create(cluster, index, document, id, params \\ [], opts \\ []) do
-    namespaced_index = Namespace.add_namespace_to_index(index, cluster)
-    Snap.post(cluster, "/#{namespaced_index}/_create/#{id}", document, params, [], opts)
+    index = index |> Namespace.add_namespace_to_index(cluster) |> Request.encode_segment()
+    id = Request.encode_segment(id)
+    Snap.post(cluster, "/#{index}/_create/#{id}", document, params, [], opts)
   end
 
   @doc """
   Creates or updates a document in the index with the specified ID. Overwrite it if it already exists.
   """
   def index(cluster, index, document, id, params \\ [], opts \\ []) do
-    namespaced_index = Namespace.add_namespace_to_index(index, cluster)
-    Snap.put(cluster, "/#{namespaced_index}/_doc/#{id}", document, params, [], opts)
+    index = index |> Namespace.add_namespace_to_index(cluster) |> Request.encode_segment()
+    id = Request.encode_segment(id)
+    Snap.put(cluster, "/#{index}/_doc/#{id}", document, params, [], opts)
   end
 
   @doc """
   Creates a new document in the index. The ID will be assigned automatically.
   """
   def add(cluster, index, document, params \\ [], opts \\ []) do
-    namespaced_index = Namespace.add_namespace_to_index(index, cluster)
-    Snap.post(cluster, "/#{namespaced_index}/_doc", document, params, [], opts)
+    index = index |> Namespace.add_namespace_to_index(cluster) |> Request.encode_segment()
+    Snap.post(cluster, "/#{index}/_doc", document, params, [], opts)
   end
 
   @doc """
@@ -43,15 +47,17 @@ defmodule Snap.Document do
   performed](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-update.html).
   """
   def update(cluster, index, body, id, params \\ [], opts \\ []) do
-    namespaced_index = Namespace.add_namespace_to_index(index, cluster)
-    Snap.post(cluster, "/#{namespaced_index}/_update/#{id}", body, params, [], opts)
+    index = index |> Namespace.add_namespace_to_index(cluster) |> Request.encode_segment()
+    id = Request.encode_segment(id)
+    Snap.post(cluster, "/#{index}/_update/#{id}", body, params, [], opts)
   end
 
   @doc """
   Deletes a document in the index at the specified ID.
   """
   def delete(cluster, index, id, params \\ [], opts \\ []) do
-    namespaced_index = Namespace.add_namespace_to_index(index, cluster)
-    Snap.delete(cluster, "/#{namespaced_index}/_doc/#{id}", params, [], opts)
+    index = index |> Namespace.add_namespace_to_index(cluster) |> Request.encode_segment()
+    id = Request.encode_segment(id)
+    Snap.delete(cluster, "/#{index}/_doc/#{id}", params, [], opts)
   end
 end

--- a/lib/snap/indexes.ex
+++ b/lib/snap/indexes.ex
@@ -7,6 +7,7 @@ defmodule Snap.Indexes do
   alias Snap.BulkError
   alias Snap.Cluster
   alias Snap.Cluster.Namespace
+  alias Snap.Request
 
   @doc """
   Creates an index.
@@ -14,7 +15,9 @@ defmodule Snap.Indexes do
   @spec create(module(), String.t(), map()) :: Cluster.result()
   @spec create(module(), String.t(), map(), Keyword.t()) :: Cluster.result()
   def create(cluster, index, mapping, opts \\ []) do
-    namespaced_index = Namespace.add_namespace_to_index(index, cluster)
+    namespaced_index =
+      index |> Namespace.add_namespace_to_index(cluster) |> Request.encode_segment()
+
     Snap.put(cluster, "/#{namespaced_index}", mapping, [], [], opts)
   end
 
@@ -24,7 +27,9 @@ defmodule Snap.Indexes do
   @spec delete(module(), String.t()) :: Cluster.result()
   @spec delete(module(), String.t(), Keyword.t()) :: Cluster.result()
   def delete(cluster, index, opts \\ []) do
-    namespaced_index = Namespace.add_namespace_to_index(index, cluster)
+    namespaced_index =
+      index |> Namespace.add_namespace_to_index(cluster) |> Request.encode_segment()
+
     Snap.delete(cluster, "/#{namespaced_index}", [], [], opts)
   end
 
@@ -34,7 +39,9 @@ defmodule Snap.Indexes do
   @spec get_mapping(module(), String.t()) :: Cluster.result()
   @spec get_mapping(module(), String.t(), Keyword.t()) :: Cluster.result()
   def get_mapping(cluster, index, opts \\ []) do
-    namespaced_index = Namespace.add_namespace_to_index(index, cluster)
+    namespaced_index =
+      index |> Namespace.add_namespace_to_index(cluster) |> Request.encode_segment()
+
     Snap.get(cluster, "/#{namespaced_index}/_mapping", [], [], opts)
   end
 
@@ -46,7 +53,9 @@ defmodule Snap.Indexes do
   @spec update_mapping(module(), String.t(), map()) :: Cluster.result()
   @spec update_mapping(module(), String.t(), map(), Keyword.t()) :: Cluster.result()
   def update_mapping(cluster, index, mapping, opts \\ []) do
-    namespaced_index = Namespace.add_namespace_to_index(index, cluster)
+    namespaced_index =
+      index |> Namespace.add_namespace_to_index(cluster) |> Request.encode_segment()
+
     Snap.put(cluster, "/#{namespaced_index}/_mapping", mapping, [], [], opts)
   end
 
@@ -59,7 +68,9 @@ defmodule Snap.Indexes do
   @spec get_settings(module(), String.t(), Keyword.t()) :: Cluster.result()
   @spec get_settings(module(), String.t(), Keyword.t(), Keyword.t()) :: Cluster.result()
   def get_settings(cluster, index, params \\ [], opts \\ []) do
-    namespaced_index = Namespace.add_namespace_to_index(index, cluster)
+    namespaced_index =
+      index |> Namespace.add_namespace_to_index(cluster) |> Request.encode_segment()
+
     Snap.get(cluster, "/#{namespaced_index}/_settings", params, [], opts)
   end
 
@@ -73,7 +84,10 @@ defmodule Snap.Indexes do
   @spec get_setting(module(), String.t(), String.t(), Keyword.t(), Keyword.t()) ::
           Cluster.result()
   def get_setting(cluster, index, setting, params \\ [], opts \\ []) do
-    namespaced_index = Namespace.add_namespace_to_index(index, cluster)
+    namespaced_index =
+      index |> Namespace.add_namespace_to_index(cluster) |> Request.encode_segment()
+
+    setting = Request.encode_segment(setting)
     Snap.get(cluster, "/#{namespaced_index}/_settings/#{setting}", params, [], opts)
   end
 
@@ -86,7 +100,9 @@ defmodule Snap.Indexes do
   @spec update_settings(module(), String.t(), map(), Keyword.t()) :: Cluster.result()
   @spec update_settings(module(), String.t(), map(), Keyword.t(), Keyword.t()) :: Cluster.result()
   def update_settings(cluster, index, settings, params \\ [], opts \\ []) do
-    namespaced_index = Namespace.add_namespace_to_index(index, cluster)
+    namespaced_index =
+      index |> Namespace.add_namespace_to_index(cluster) |> Request.encode_segment()
+
     Snap.put(cluster, "/#{namespaced_index}/_settings", settings, params, [], opts)
   end
 
@@ -99,7 +115,9 @@ defmodule Snap.Indexes do
   @spec get_shard_stores(module(), String.t(), Keyword.t()) :: Cluster.result()
   @spec get_shard_stores(module(), String.t(), Keyword.t(), Keyword.t()) :: Cluster.result()
   def get_shard_stores(cluster, index, params \\ [], opts \\ []) do
-    namespaced_index = Namespace.add_namespace_to_index(index, cluster)
+    namespaced_index =
+      index |> Namespace.add_namespace_to_index(cluster) |> Request.encode_segment()
+
     Snap.get(cluster, "/#{namespaced_index}/_shard_stores", params, [], opts)
   end
 
@@ -112,7 +130,9 @@ defmodule Snap.Indexes do
   @spec get_stats(module(), String.t(), Keyword.t()) :: Cluster.result()
   @spec get_stats(module(), String.t(), Keyword.t(), Keyword.t()) :: Cluster.result()
   def get_stats(cluster, index, params \\ [], opts \\ []) do
-    namespaced_index = Namespace.add_namespace_to_index(index, cluster)
+    namespaced_index =
+      index |> Namespace.add_namespace_to_index(cluster) |> Request.encode_segment()
+
     Snap.get(cluster, "/#{namespaced_index}/_stats", params, [], opts)
   end
 
@@ -125,7 +145,10 @@ defmodule Snap.Indexes do
   @spec get_stat(module(), String.t(), String.t(), Keyword.t()) :: Cluster.result()
   @spec get_stat(module(), String.t(), String.t(), Keyword.t(), Keyword.t()) :: Cluster.result()
   def get_stat(cluster, index, metric, params \\ [], opts \\ []) do
-    namespaced_index = Namespace.add_namespace_to_index(index, cluster)
+    namespaced_index =
+      index |> Namespace.add_namespace_to_index(cluster) |> Request.encode_segment()
+
+    metric = Request.encode_segment(metric)
     Snap.get(cluster, "/#{namespaced_index}/_stats/#{metric}", params, [], opts)
   end
 
@@ -138,7 +161,9 @@ defmodule Snap.Indexes do
   @spec close(module(), String.t(), Keyword.t()) :: Cluster.result()
   @spec close(module(), String.t(), Keyword.t(), Keyword.t()) :: Cluster.result()
   def close(cluster, index, params \\ [], opts \\ []) do
-    namespaced_index = Namespace.add_namespace_to_index(index, cluster)
+    namespaced_index =
+      index |> Namespace.add_namespace_to_index(cluster) |> Request.encode_segment()
+
     Snap.post(cluster, "/#{namespaced_index}/_close", [], params, [], opts)
   end
 
@@ -151,7 +176,9 @@ defmodule Snap.Indexes do
   @spec open(module(), String.t(), Keyword.t()) :: Cluster.result()
   @spec open(module(), String.t(), Keyword.t(), Keyword.t()) :: Cluster.result()
   def open(cluster, index, params \\ [], opts \\ []) do
-    namespaced_index = Namespace.add_namespace_to_index(index, cluster)
+    namespaced_index =
+      index |> Namespace.add_namespace_to_index(cluster) |> Request.encode_segment()
+
     Snap.post(cluster, "/#{namespaced_index}/_open", [], params, [], opts)
   end
 
@@ -185,7 +212,8 @@ defmodule Snap.Indexes do
   @spec refresh(cluster :: module(), index :: String.t(), opts :: Keyword.t()) ::
           :ok | Cluster.error()
   def refresh(cluster, index, opts \\ []) do
-    namespaced_index = Namespace.add_namespace_to_index(index, cluster)
+    namespaced_index =
+      index |> Namespace.add_namespace_to_index(cluster) |> Request.encode_segment()
 
     with {:ok, _} <- Snap.post(cluster, "/#{namespaced_index}/_refresh", nil, [], [], opts) do
       :ok

--- a/lib/snap/multi/multi.ex
+++ b/lib/snap/multi/multi.ex
@@ -69,7 +69,9 @@ defmodule Snap.Multi do
     json_library = cluster.json_library()
     body = encode(multi, json_library)
     headers = headers ++ [{"content-type", "application/x-ndjson"}]
-    namespaced_index = Namespace.add_namespace_to_index(index_or_alias, cluster)
+
+    namespaced_index =
+      index_or_alias |> Namespace.add_namespace_to_index(cluster) |> Snap.Request.encode_segment()
 
     case cluster.post("/#{namespaced_index}/_msearch", body, params, headers, opts) do
       {:ok, response} -> {:ok, Response.new(response, ids)}

--- a/lib/snap/request.ex
+++ b/lib/snap/request.ex
@@ -15,6 +15,16 @@ defmodule Snap.Request do
   ]
 
   @doc """
+  URI-encodes a single path segment using the RFC 3986 unreserved set, so a
+  caller-supplied value (index name, document ID, metric, etc.) can't smuggle
+  `?`, `#`, or `/` into the request path.
+  """
+  @spec encode_segment(String.t() | atom() | number()) :: String.t()
+  def encode_segment(segment) do
+    segment |> to_string() |> URI.encode(&URI.char_unreserved?/1)
+  end
+
+  @doc """
   Makes an HTTP request against a `Snap.Cluster`
   """
   def request(cluster, method, path, body \\ nil, params \\ [], headers \\ [], opts \\ []) do

--- a/lib/snap/search.ex
+++ b/lib/snap/search.ex
@@ -4,6 +4,7 @@ defmodule Snap.Search do
   """
   alias Snap.Cluster.Namespace
   alias Snap.DeleteResponse
+  alias Snap.Request
   alias Snap.SearchResponse
 
   @spec search(
@@ -32,7 +33,8 @@ defmodule Snap.Search do
       Enum.each(response, fn hit -> IO.inspect(hit.score) end)
   """
   def search(cluster, index_or_alias, query, params \\ [], headers \\ [], opts \\ []) do
-    namespaced_index = Namespace.add_namespace_to_index(index_or_alias, cluster)
+    namespaced_index =
+      index_or_alias |> Namespace.add_namespace_to_index(cluster) |> Request.encode_segment()
 
     case cluster.post("/#{namespaced_index}/_search", query, params, headers, opts) do
       {:ok, response} -> {:ok, SearchResponse.new(response)}
@@ -44,7 +46,8 @@ defmodule Snap.Search do
   Runs a count of the documents in an index, using an optional query.
   """
   def count(cluster, index_or_alias, query \\ %{}, params \\ [], headers \\ [], opts \\ []) do
-    namespaced_index = Namespace.add_namespace_to_index(index_or_alias, cluster)
+    namespaced_index =
+      index_or_alias |> Namespace.add_namespace_to_index(cluster) |> Request.encode_segment()
 
     case cluster.post("/#{namespaced_index}/_count", query, params, headers, opts) do
       {:ok, %{"count" => count}} -> {:ok, count}
@@ -56,7 +59,8 @@ defmodule Snap.Search do
   Runs a delete operation on an index, given a query.
   """
   def delete_by_query(cluster, index_or_alias, query, params \\ [], headers \\ [], opts \\ []) do
-    namespaced_index = Namespace.add_namespace_to_index(index_or_alias, cluster)
+    namespaced_index =
+      index_or_alias |> Namespace.add_namespace_to_index(cluster) |> Request.encode_segment()
 
     case cluster.post("/#{namespaced_index}/_delete_by_query", query, params, headers, opts) do
       {:ok, response} -> {:ok, DeleteResponse.new(response)}

--- a/test/request_test.exs
+++ b/test/request_test.exs
@@ -1,5 +1,5 @@
 defmodule Snap.RequestTest do
-  use Snap.IntegrationCase, async: true
+  use ExUnit.Case, async: true
 
   alias Snap.Request
   alias Snap.Test.Cluster
@@ -79,6 +79,50 @@ defmodule Snap.RequestTest do
                {:error, %Snap.InvalidPathError{}},
                Request.request(Cluster, :get, "/users/_doc/hello%20world")
              )
+    end
+  end
+
+  describe "encode_segment/1" do
+    @describetag integration: false
+
+    test "percent-encodes `?` so it can't open a query string" do
+      assert Request.encode_segment("1?refresh=wait_for") ==
+               "1%3Frefresh%3Dwait_for"
+    end
+
+    test "percent-encodes `#` so it can't open a fragment" do
+      assert Request.encode_segment("1#frag") == "1%23frag"
+    end
+
+    test "percent-encodes `/` so it can't add path segments" do
+      assert Request.encode_segment("a/b") == "a%2Fb"
+    end
+
+    test "percent-encodes `&` and `=` that could smuggle extra params" do
+      assert Request.encode_segment("x&y=z") == "x%26y%3Dz"
+    end
+
+    test "leaves RFC 3986 unreserved characters untouched" do
+      assert Request.encode_segment("abcXYZ-._~0123") == "abcXYZ-._~0123"
+    end
+
+    test "coerces non-string inputs via to_string/1" do
+      assert Request.encode_segment(42) == "42"
+      assert Request.encode_segment(:foo) == "foo"
+    end
+
+    test "after encoding, re-parsing the URL does not expose a query string" do
+      malicious = "1?refresh=wait_for&routing=attacker"
+      encoded = Request.encode_segment(malicious)
+
+      url =
+        URI.parse("http://localhost:9200")
+        |> URI.append_path("/idx/_doc/#{encoded}")
+        |> URI.to_string()
+
+      reparsed = URI.parse(url)
+      assert reparsed.query == nil
+      assert reparsed.path == "/idx/_doc/1%3Frefresh%3Dwait_for%26routing%3Dattacker"
     end
   end
 end


### PR DESCRIPTION
It's possible for an index or document ID to contain characters that have special meaning in URLs, such as `?`, `#`, or `/`. If these values are not properly escaped, an attacker could smuggle extra query parameters or path segments into the request. This commit adds a `Request.encode_segment/1` function that URI-encodes index names, document IDs, and other path segments using the RFC 3986 unreserved character set, and applies it to all relevant API calls.