### PR TITLE
Remove hotswap `wait_for_active_shards` param

### DIFF
--- a/lib/snap/indexes.ex
+++ b/lib/snap/indexes.ex
@@ -196,9 +196,8 @@ defmodule Snap.Indexes do
           :ok | Cluster.error() | {:error, BulkError.t()}
   def hotswap(stream, cluster, alias, mapping, opts \\ []) do
     index = generate_index_name(alias)
-    create_opts = [wait_for_active_shards: "all"]
 
-    with {:ok, _} <- create(cluster, index, mapping, create_opts),
+    with {:ok, _} <- create(cluster, index, mapping),
          :ok <- Bulk.perform(stream, cluster, index, opts),
          :ok <- refresh(cluster, index),
          :ok <- alias(cluster, index, alias) do


### PR DESCRIPTION
Finch 0.22.0 started validated the params passed to `Finch.request`, exposing an bug when creating a hotswap index where `wait_for_active_shared` was not being passed through a query param, but instead a Finch request option.

Since we've not been passing it through and everything has been working fine, let's drop this param.