### PR TITLE
Support multi-index inputs in namespace prefixing

### DIFF
--- a/lib/snap/namespace.ex
+++ b/lib/snap/namespace.ex
@@ -51,6 +51,7 @@ defmodule Snap.Cluster.Namespace do
   """
 
   @separator "-"
+  @index_separator ","
 
   @doc """
   Sets an index namespace for the currently running process.
@@ -81,11 +82,38 @@ defmodule Snap.Cluster.Namespace do
   @doc """
   Given an index, adds the namespace to the supplied index for the
   `Snap.Cluster` in the currently running process.
+
+  The index can be:
+
+  - a string or atom naming a single index
+  - a comma-separated string of indexes (e.g. `"foo,bar"`)
+  - a list of strings or atoms (e.g. `["foo", "bar"]`)
+
+  Multi-index inputs are returned as a comma-separated string, with each
+  index individually namespaced.
   """
+  def add_namespace_to_index(indexes, cluster) when is_list(indexes) do
+    prefix = namespace_prefix(cluster)
+    Enum.map_join(indexes, @index_separator, &apply_prefix(prefix, &1))
+  end
+
+  def add_namespace_to_index(index, cluster) when is_binary(index) do
+    String.split(index, @index_separator)
+    |> Enum.map(&String.trim/1)
+    |> add_namespace_to_index(cluster)
+  end
+
   def add_namespace_to_index(index, cluster) do
-    [config_namespace(cluster), get_process_namespace(cluster), index]
+    apply_prefix(namespace_prefix(cluster), index)
+  end
+
+  defp namespace_prefix(cluster) do
+    [config_namespace(cluster), get_process_namespace(cluster)]
     |> Enum.reject(&is_nil/1)
-    |> merge_elements()
+  end
+
+  defp apply_prefix(prefix, index) do
+    merge_elements(prefix ++ [to_string(index)])
   end
 
   @doc """

--- a/test/namespace_test.exs
+++ b/test/namespace_test.exs
@@ -48,6 +48,38 @@ defmodule Snap.Cluster.NamespaceTest do
       assert "cluster" == Namespace.index_namespace(NamespaceCluster)
       assert "cluster-foo" == Namespace.add_namespace_to_index(:foo, NamespaceCluster)
     end
+
+    test "with a comma-separated string of indexes and no cluster index_namespace" do
+      assert "foo,bar" == Namespace.add_namespace_to_index("foo,bar", NoNamespaceCluster)
+    end
+
+    test "with a comma-separated string of indexes and a cluster index_namespace" do
+      assert "cluster-foo,cluster-bar" ==
+               Namespace.add_namespace_to_index("foo,bar", NamespaceCluster)
+    end
+
+    test "with a comma-and-space-separated string of indexes and a cluster index_namespace" do
+      assert "cluster-foo,cluster-bar" ==
+               Namespace.add_namespace_to_index("foo, bar", NamespaceCluster)
+    end
+
+    test "with a list of string indexes and no cluster index_namespace" do
+      assert "foo,bar" == Namespace.add_namespace_to_index(["foo", "bar"], NoNamespaceCluster)
+    end
+
+    test "with a list of string indexes and a cluster index_namespace" do
+      assert "cluster-foo,cluster-bar" ==
+               Namespace.add_namespace_to_index(["foo", "bar"], NamespaceCluster)
+    end
+
+    test "with a list of atom indexes and a cluster index_namespace" do
+      assert "cluster-foo,cluster-bar" ==
+               Namespace.add_namespace_to_index([:foo, :bar], NamespaceCluster)
+    end
+
+    test "with a single-element list and a cluster index_namespace" do
+      assert "cluster-foo" == Namespace.add_namespace_to_index(["foo"], NamespaceCluster)
+    end
   end
 
   describe "set_process_namespace/2 and clear_process_namespace/1" do


### PR DESCRIPTION
`Snap.Cluster.Namespace.add_namespace_to_index/2` now accepts a comma-separated string (e.g. `"foo,bar"`) or a list of strings/atoms, returning a comma-separated string of individually namespaced indexes.