### PR TITLE
Add missing Bulk API fields to bulk actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+- Added the remaining Bulk API fields to the `Snap.Bulk.Action` structs:
+  - `version`, `version_type`, `if_seq_no` and `if_primary_term` on `Create`, `Index` and `Delete`
+  - `pipeline` on `Create` and `Index`
+  - `if_seq_no`, `if_primary_term`, `retry_on_conflict`, `pipeline`, `source`, `upsert`, `scripted_upsert` and `detect_noop` on `Update`
+- `Snap.Bulk.Action.Update` no longer requires `doc`, so updates can be performed with only a `script`
+
 ## 0.16.0
 
 - Added high level API for streaming an entire result set, using the Scroll API (see `Snap.Scroll` for details)

--- a/lib/snap/bulk/action.ex
+++ b/lib/snap/bulk/action.ex
@@ -2,37 +2,95 @@ defmodule Snap.Bulk.Action do
   @moduledoc false
   @callback to_action_json(struct()) :: map()
   @callback to_document_json(struct()) :: map() | nil
+
+  @typedoc """
+  The version type used for optimistic concurrency control.
+  """
+  @type version_type :: :internal | :external | :external_gte | String.t()
+
+  @typedoc """
+  Controls which parts of the document `_source` are returned for an action.
+
+  Either a boolean, a wildcard string, a list of wildcard strings, or a map of
+  `includes` and `excludes`.
+  """
+  @type source :: boolean() | String.t() | [String.t()] | map()
+
+  @doc false
+  def compact(values) do
+    values
+    |> Enum.reject(&is_nil(elem(&1, 1)))
+    |> Enum.into(%{})
+  end
 end
 
 defmodule Snap.Bulk.Action.Create do
   @moduledoc """
-  Represents a create step in a `Snap.Bulk` operation
+  Represents a create step in a `Snap.Bulk` operation.
+
+  Creates a document if it does not already exist, returning an error
+  otherwise.
+
+  Supports the following fields:
+
+  * `doc` - the document to index (required)
+  * `index` - the index to write to, if not specified on the bulk operation
+  * `id` - the document ID. Elasticsearch generates one if it is omitted
+  * `require_alias` - when `true`, the destination must be an index alias
+  * `routing` - the custom routing value for the document
+  * `version` - the explicit version number, for optimistic concurrency control
+  * `version_type` - one of `:internal`, `:external` or `:external_gte`
+  * `if_seq_no` - only perform the action if the document has this sequence
+    number
+  * `if_primary_term` - only perform the action if the document has this
+    primary term
+  * `pipeline` - the ingest pipeline to run the document through
   """
   @behaviour Snap.Bulk.Action
 
+  alias Snap.Bulk.Action
+
   @enforce_keys [:doc]
-  defstruct [:index, :id, :require_alias, :doc, :routing]
+  defstruct [
+    :index,
+    :id,
+    :require_alias,
+    :doc,
+    :routing,
+    :version,
+    :version_type,
+    :if_seq_no,
+    :if_primary_term,
+    :pipeline
+  ]
 
   @type t :: %__MODULE__{
           index: String.t() | nil,
           id: String.t() | nil,
           require_alias: boolean() | nil,
           doc: map(),
-          routing: String.t() | nil
+          routing: String.t() | nil,
+          version: integer() | nil,
+          version_type: Action.version_type() | nil,
+          if_seq_no: integer() | nil,
+          if_primary_term: integer() | nil,
+          pipeline: String.t() | nil
         }
 
   @doc false
-  def to_action_json(%__MODULE__{
-        index: index,
-        id: id,
-        require_alias: require_alias,
-        routing: routing
-      }) do
-    values = %{_index: index, _id: id, require_alias: require_alias, routing: routing}
-
-    values
-    |> Enum.reject(&is_nil(elem(&1, 1)))
-    |> Enum.into(%{})
+  def to_action_json(%__MODULE__{} = action) do
+    %{
+      _index: action.index,
+      _id: action.id,
+      require_alias: action.require_alias,
+      routing: action.routing,
+      version: action.version,
+      version_type: action.version_type,
+      if_seq_no: action.if_seq_no,
+      if_primary_term: action.if_primary_term,
+      pipeline: action.pipeline
+    }
+    |> Action.compact()
     |> then(fn values -> %{"create" => values} end)
   end
 
@@ -44,32 +102,61 @@ end
 
 defmodule Snap.Bulk.Action.Delete do
   @moduledoc """
-  Represents a delete step in a `Snap.Bulk` operation
+  Represents a delete step in a `Snap.Bulk` operation.
+
+  Supports the following fields:
+
+  * `id` - the document ID to delete (required)
+  * `index` - the index to delete from, if not specified on the bulk operation
+  * `require_alias` - when `true`, the destination must be an index alias
+  * `routing` - the custom routing value for the document
+  * `version` - the explicit version number, for optimistic concurrency control
+  * `version_type` - one of `:internal`, `:external` or `:external_gte`
+  * `if_seq_no` - only perform the action if the document has this sequence
+    number
+  * `if_primary_term` - only perform the action if the document has this
+    primary term
   """
   @behaviour Snap.Bulk.Action
 
+  alias Snap.Bulk.Action
+
   @enforce_keys [:id]
-  defstruct [:index, :id, :require_alias, :routing]
+  defstruct [
+    :index,
+    :id,
+    :require_alias,
+    :routing,
+    :version,
+    :version_type,
+    :if_seq_no,
+    :if_primary_term
+  ]
 
   @type t :: %__MODULE__{
           index: String.t() | nil,
           id: String.t(),
           require_alias: boolean() | nil,
-          routing: String.t() | nil
+          routing: String.t() | nil,
+          version: integer() | nil,
+          version_type: Action.version_type() | nil,
+          if_seq_no: integer() | nil,
+          if_primary_term: integer() | nil
         }
 
   @doc false
-  def to_action_json(%__MODULE__{
-        index: index,
-        id: id,
-        require_alias: require_alias,
-        routing: routing
-      }) do
-    values = %{_index: index, _id: id, require_alias: require_alias, routing: routing}
-
-    values
-    |> Enum.reject(&is_nil(elem(&1, 1)))
-    |> Enum.into(%{})
+  def to_action_json(%__MODULE__{} = action) do
+    %{
+      _index: action.index,
+      _id: action.id,
+      require_alias: action.require_alias,
+      routing: action.routing,
+      version: action.version,
+      version_type: action.version_type,
+      if_seq_no: action.if_seq_no,
+      if_primary_term: action.if_primary_term
+    }
+    |> Action.compact()
     |> then(fn values -> %{"delete" => values} end)
   end
 
@@ -79,33 +166,70 @@ end
 
 defmodule Snap.Bulk.Action.Index do
   @moduledoc """
-  Represents an index step in a `Snap.Bulk` operation
+  Represents an index step in a `Snap.Bulk` operation.
+
+  Creates a document if it does not yet exist, and replaces it if it does.
+
+  Supports the following fields:
+
+  * `doc` - the document to index (required)
+  * `index` - the index to write to, if not specified on the bulk operation
+  * `id` - the document ID. Elasticsearch generates one if it is omitted
+  * `require_alias` - when `true`, the destination must be an index alias
+  * `routing` - the custom routing value for the document
+  * `version` - the explicit version number, for optimistic concurrency control
+  * `version_type` - one of `:internal`, `:external` or `:external_gte`
+  * `if_seq_no` - only perform the action if the document has this sequence
+    number
+  * `if_primary_term` - only perform the action if the document has this
+    primary term
+  * `pipeline` - the ingest pipeline to run the document through
   """
   @behaviour Snap.Bulk.Action
 
+  alias Snap.Bulk.Action
+
   @enforce_keys [:doc]
-  defstruct [:index, :id, :require_alias, :doc, :routing]
+  defstruct [
+    :index,
+    :id,
+    :require_alias,
+    :doc,
+    :routing,
+    :version,
+    :version_type,
+    :if_seq_no,
+    :if_primary_term,
+    :pipeline
+  ]
 
   @type t :: %__MODULE__{
           index: String.t() | nil,
           id: String.t() | nil,
           require_alias: boolean() | nil,
           doc: map(),
-          routing: String.t() | nil
+          routing: String.t() | nil,
+          version: integer() | nil,
+          version_type: Action.version_type() | nil,
+          if_seq_no: integer() | nil,
+          if_primary_term: integer() | nil,
+          pipeline: String.t() | nil
         }
 
   @doc false
-  def to_action_json(%__MODULE__{
-        index: index,
-        id: id,
-        require_alias: require_alias,
-        routing: routing
-      }) do
-    values = %{_index: index, _id: id, require_alias: require_alias, routing: routing}
-
-    values
-    |> Enum.reject(&is_nil(elem(&1, 1)))
-    |> Enum.into(%{})
+  def to_action_json(%__MODULE__{} = action) do
+    %{
+      _index: action.index,
+      _id: action.id,
+      require_alias: action.require_alias,
+      routing: action.routing,
+      version: action.version,
+      version_type: action.version_type,
+      if_seq_no: action.if_seq_no,
+      if_primary_term: action.if_primary_term,
+      pipeline: action.pipeline
+    }
+    |> Action.compact()
     |> then(fn values -> %{"index" => values} end)
   end
 
@@ -117,11 +241,45 @@ end
 
 defmodule Snap.Bulk.Action.Update do
   @moduledoc """
-  Represents an update step in a `Snap.Bulk` operation
+  Represents an update step in a `Snap.Bulk` operation.
+
+  Updates an existing document, returning an error if it does not exist,
+  unless an upsert is configured.
+
+  Supports the following action fields:
+
+  * `index` - the index to write to, if not specified on the bulk operation
+  * `id` - the document ID to update
+  * `require_alias` - when `true`, the destination must be an index alias
+  * `routing` - the custom routing value for the document
+  * `if_seq_no` - only perform the action if the document has this sequence
+    number
+  * `if_primary_term` - only perform the action if the document has this
+    primary term
+  * `retry_on_conflict` - how many times to retry the update if a version
+    conflict occurs
+  * `pipeline` - the ingest pipeline to run an upserted document through
+  * `source` - which parts of the updated `_source` to return
+
+  Note that updates do not support `version`/`version_type`. Use `if_seq_no`
+  and `if_primary_term` instead.
+
+  Along with the following document fields:
+
+  * `doc` - the partial document to merge into the existing one
+  * `doc_as_upsert` - when `true`, `doc` is indexed if the document does not
+    already exist
+  * `script` - a script to run against the existing document, instead of `doc`
+  * `upsert` - the document to index if it does not already exist
+  * `scripted_upsert` - when `true`, `script` is run against `upsert` when the
+    document does not already exist
+  * `detect_noop` - when `false`, the document is always reindexed, even if
+    `doc` makes no changes to it
   """
   @behaviour Snap.Bulk.Action
 
-  @enforce_keys [:doc]
+  alias Snap.Bulk.Action
+
   defstruct [
     :id,
     :index,
@@ -129,40 +287,62 @@ defmodule Snap.Bulk.Action.Update do
     :doc,
     :doc_as_upsert,
     :script,
-    :routing
+    :upsert,
+    :scripted_upsert,
+    :detect_noop,
+    :routing,
+    :if_seq_no,
+    :if_primary_term,
+    :retry_on_conflict,
+    :pipeline,
+    :source
   ]
 
   @type t :: %__MODULE__{
           id: String.t() | nil,
           index: String.t() | nil,
           require_alias: boolean() | nil,
-          doc: map(),
+          doc: map() | nil,
           doc_as_upsert: boolean() | nil,
           script: map() | nil,
-          routing: String.t() | nil
+          upsert: map() | nil,
+          scripted_upsert: boolean() | nil,
+          detect_noop: boolean() | nil,
+          routing: String.t() | nil,
+          if_seq_no: integer() | nil,
+          if_primary_term: integer() | nil,
+          retry_on_conflict: integer() | nil,
+          pipeline: String.t() | nil,
+          source: Action.source() | nil
         }
 
   @doc false
-  def to_action_json(%__MODULE__{
-        index: index,
-        id: id,
-        require_alias: require_alias,
-        routing: routing
-      }) do
-    values = %{_index: index, _id: id, require_alias: require_alias, routing: routing}
-
-    values
-    |> Enum.reject(&is_nil(elem(&1, 1)))
-    |> Enum.into(%{})
+  def to_action_json(%__MODULE__{} = action) do
+    %{
+      _index: action.index,
+      _id: action.id,
+      require_alias: action.require_alias,
+      routing: action.routing,
+      if_seq_no: action.if_seq_no,
+      if_primary_term: action.if_primary_term,
+      retry_on_conflict: action.retry_on_conflict,
+      pipeline: action.pipeline,
+      _source: action.source
+    }
+    |> Action.compact()
     |> then(fn values -> %{"update" => values} end)
   end
 
   @doc false
-  def to_document_json(%__MODULE__{doc: doc, doc_as_upsert: doc_as_upsert, script: script}) do
-    values = %{doc: doc, doc_as_upsert: doc_as_upsert, script: script}
-
-    values
-    |> Enum.reject(&is_nil(elem(&1, 1)))
-    |> Enum.into(%{})
+  def to_document_json(%__MODULE__{} = action) do
+    %{
+      doc: action.doc,
+      doc_as_upsert: action.doc_as_upsert,
+      script: action.script,
+      upsert: action.upsert,
+      scripted_upsert: action.scripted_upsert,
+      detect_noop: action.detect_noop
+    }
+    |> Action.compact()
   end
 end

--- a/test/bulk/actions_test.exs
+++ b/test/bulk/actions_test.exs
@@ -32,4 +32,165 @@ defmodule Snap.Bulk.ActionsTest do
              %{"delete" => %{"_index" => "foo", "_id" => 1}}
            ]
   end
+
+  test "encoding an index action with all fields" do
+    doc = %{"foo" => "bar"}
+
+    action = %Action.Index{
+      index: "foo",
+      id: "1",
+      doc: doc,
+      require_alias: true,
+      routing: "baz",
+      version: 3,
+      version_type: :external,
+      if_seq_no: 10,
+      if_primary_term: 2,
+      pipeline: "my-pipeline"
+    }
+
+    assert encode([action]) == [
+             %{
+               "index" => %{
+                 "_index" => "foo",
+                 "_id" => "1",
+                 "require_alias" => true,
+                 "routing" => "baz",
+                 "version" => 3,
+                 "version_type" => "external",
+                 "if_seq_no" => 10,
+                 "if_primary_term" => 2,
+                 "pipeline" => "my-pipeline"
+               }
+             },
+             doc
+           ]
+  end
+
+  test "encoding a create action with all fields" do
+    doc = %{"foo" => "bar"}
+
+    action = %Action.Create{
+      index: "foo",
+      id: "1",
+      doc: doc,
+      require_alias: true,
+      routing: "baz",
+      version: 3,
+      version_type: :external_gte,
+      if_seq_no: 10,
+      if_primary_term: 2,
+      pipeline: "my-pipeline"
+    }
+
+    assert encode([action]) == [
+             %{
+               "create" => %{
+                 "_index" => "foo",
+                 "_id" => "1",
+                 "require_alias" => true,
+                 "routing" => "baz",
+                 "version" => 3,
+                 "version_type" => "external_gte",
+                 "if_seq_no" => 10,
+                 "if_primary_term" => 2,
+                 "pipeline" => "my-pipeline"
+               }
+             },
+             doc
+           ]
+  end
+
+  test "encoding a delete action with all fields" do
+    action = %Action.Delete{
+      index: "foo",
+      id: "1",
+      require_alias: true,
+      routing: "baz",
+      version: 3,
+      version_type: "internal",
+      if_seq_no: 10,
+      if_primary_term: 2
+    }
+
+    assert encode([action]) == [
+             %{
+               "delete" => %{
+                 "_index" => "foo",
+                 "_id" => "1",
+                 "require_alias" => true,
+                 "routing" => "baz",
+                 "version" => 3,
+                 "version_type" => "internal",
+                 "if_seq_no" => 10,
+                 "if_primary_term" => 2
+               }
+             }
+           ]
+  end
+
+  test "encoding an update action with all fields" do
+    doc = %{"foo" => "bar"}
+    upsert = %{"foo" => "baz"}
+    script = %{"source" => "ctx._source.foo = 'bar'"}
+
+    action = %Action.Update{
+      index: "foo",
+      id: "1",
+      require_alias: true,
+      routing: "baz",
+      if_seq_no: 10,
+      if_primary_term: 2,
+      retry_on_conflict: 3,
+      pipeline: "my-pipeline",
+      source: ["foo"],
+      doc: doc,
+      doc_as_upsert: false,
+      script: script,
+      upsert: upsert,
+      scripted_upsert: true,
+      detect_noop: false
+    }
+
+    assert encode([action]) == [
+             %{
+               "update" => %{
+                 "_index" => "foo",
+                 "_id" => "1",
+                 "require_alias" => true,
+                 "routing" => "baz",
+                 "if_seq_no" => 10,
+                 "if_primary_term" => 2,
+                 "retry_on_conflict" => 3,
+                 "pipeline" => "my-pipeline",
+                 "_source" => ["foo"]
+               }
+             },
+             %{
+               "doc" => doc,
+               "doc_as_upsert" => false,
+               "script" => script,
+               "upsert" => upsert,
+               "scripted_upsert" => true,
+               "detect_noop" => false
+             }
+           ]
+  end
+
+  test "encoding an update action with only a script" do
+    script = %{"source" => "ctx._source.counter += 1"}
+
+    assert encode([%Action.Update{id: "1", script: script}]) == [
+             %{"update" => %{"_id" => "1"}},
+             %{"script" => script}
+           ]
+  end
+
+  defp encode(actions) do
+    actions
+    |> Actions.encode()
+    |> IO.chardata_to_string()
+    |> String.split("\n", trim: true)
+    |> Enum.map(&Jason.decode!/1)
+  end
 end

--- a/test/bulk/bulk_test.exs
+++ b/test/bulk/bulk_test.exs
@@ -110,5 +110,120 @@ defmodule Snap.BulkTest do
                actions
                |> Bulk.perform(Cluster, @test_index, page_size: 2, page_wait: 10, max_errors: 0)
     end
+
+    test "upserting with doc_as_upsert" do
+      {:ok, _} = Snap.Indexes.create(Cluster, @test_index, %{})
+
+      actions = [
+        %Action.Update{id: 1, doc: %{foo: "bar"}, doc_as_upsert: true}
+      ]
+
+      assert :ok == Bulk.perform(actions, Cluster, @test_index)
+
+      assert {:ok, %{"_source" => %{"foo" => "bar"}}} =
+               Snap.Document.get(Cluster, @test_index, 1)
+    end
+
+    test "upserting with an explicit upsert document" do
+      {:ok, _} = Snap.Indexes.create(Cluster, @test_index, %{})
+
+      actions = [
+        %Action.Update{id: 1, doc: %{foo: "bar"}, upsert: %{foo: "baz", count: 1}}
+      ]
+
+      assert :ok == Bulk.perform(actions, Cluster, @test_index)
+
+      assert {:ok, %{"_source" => %{"foo" => "baz", "count" => 1}}} =
+               Snap.Document.get(Cluster, @test_index, 1)
+    end
+
+    test "updating with a script and no doc" do
+      {:ok, _} = Snap.Indexes.create(Cluster, @test_index, %{})
+
+      actions = [
+        %Action.Index{id: 1, doc: %{count: 1}},
+        %Action.Update{
+          id: 1,
+          script: %{source: "ctx._source.count += params.by", params: %{by: 4}},
+          retry_on_conflict: 3
+        }
+      ]
+
+      assert :ok == Bulk.perform(actions, Cluster, @test_index)
+
+      assert {:ok, %{"_source" => %{"count" => 5}}} = Snap.Document.get(Cluster, @test_index, 1)
+    end
+
+    test "updating with a scripted upsert" do
+      {:ok, _} = Snap.Indexes.create(Cluster, @test_index, %{})
+
+      actions = [
+        %Action.Update{
+          id: 1,
+          script: %{source: "ctx._source.count = params.count", params: %{count: 7}},
+          upsert: %{},
+          scripted_upsert: true
+        }
+      ]
+
+      assert :ok == Bulk.perform(actions, Cluster, @test_index)
+
+      assert {:ok, %{"_source" => %{"count" => 7}}} = Snap.Document.get(Cluster, @test_index, 1)
+    end
+
+    test "indexing with an external version" do
+      {:ok, _} = Snap.Indexes.create(Cluster, @test_index, %{})
+
+      actions = [
+        %Action.Index{id: 1, doc: %{foo: "bar"}, version: 5, version_type: :external}
+      ]
+
+      assert :ok == Bulk.perform(actions, Cluster, @test_index)
+
+      assert {:ok, %{"_version" => 5}} = Snap.Document.get(Cluster, @test_index, 1)
+
+      stale = [
+        %Action.Index{id: 1, doc: %{foo: "baz"}, version: 4, version_type: :external}
+      ]
+
+      assert {:error, %Snap.BulkError{errors: [error]}} =
+               Bulk.perform(stale, Cluster, @test_index)
+
+      assert error.type == "version_conflict_engine_exception"
+    end
+
+    test "indexing with if_seq_no and if_primary_term" do
+      {:ok, _} = Snap.Indexes.create(Cluster, @test_index, %{})
+
+      assert :ok == Bulk.perform([%Action.Index{id: 1, doc: %{foo: "bar"}}], Cluster, @test_index)
+
+      {:ok, %{"_seq_no" => seq_no, "_primary_term" => primary_term}} =
+        Snap.Document.get(Cluster, @test_index, 1)
+
+      actions = [
+        %Action.Index{
+          id: 1,
+          doc: %{foo: "baz"},
+          if_seq_no: seq_no,
+          if_primary_term: primary_term
+        }
+      ]
+
+      assert :ok == Bulk.perform(actions, Cluster, @test_index)
+
+      stale = [
+        %Action.Index{
+          id: 1,
+          doc: %{foo: "qux"},
+          if_seq_no: seq_no,
+          if_primary_term: primary_term
+        }
+      ]
+
+      assert {:error, %Snap.BulkError{errors: [error]}} =
+               Bulk.perform(stale, Cluster, @test_index)
+
+      assert error.type == "version_conflict_engine_exception"
+    end
   end
 end


### PR DESCRIPTION
## What changed

`Snap.Bulk.Action.{Create,Index,Delete,Update}` now cover the full set of fields the Bulk API accepts.

| Field | Create | Index | Delete | Update |
|---|:-:|:-:|:-:|:-:|
| `version`, `version_type` | ✅ new | ✅ new | ✅ new | — |
| `if_seq_no`, `if_primary_term` | ✅ new | ✅ new | ✅ new | ✅ new |
| `pipeline` | ✅ new | ✅ new | — | ✅ new |
| `retry_on_conflict`, `source` (`_source`) | — | — | — | ✅ new |
| `upsert`, `scripted_upsert`, `detect_noop` | — | — | — | ✅ new (document line) |

Existing `index`, `id`, `require_alias`, `routing`, `doc`, `doc_as_upsert` and `script` are unchanged.

`Update` also no longer has `@enforce_keys [:doc]`.

## Why

Optimistic concurrency control (`if_seq_no`/`if_primary_term`, `version`), per-action ingest pipelines and upserts were all unreachable through `Snap.Bulk`, so anything needing them had to drop down to raw `Snap.post/6` and hand-roll the NDJSON.

Dropping `@enforce_keys` on `Update` is what makes script-only updates and scripted upserts expressible at all — neither takes a `doc`. It only loosens the contract, so existing code is unaffected.